### PR TITLE
added workspace names to i3list

### DIFF
--- a/i3fyra/i3fyra
+++ b/i3fyra/i3fyra
@@ -39,6 +39,7 @@ main(){
   i3list[CMA]=${I3FYRA_MAIN_CONTAINER:-A}
 
   ${cmd} "${target}" # run command
+
 }
 
 familycreate(){

--- a/i3list/i3list
+++ b/i3list/i3list
@@ -102,6 +102,8 @@ printlist(){
       desc["TWB"]="Target window titlebar height"
       desc["WAW"]="Active workspace width"
       desc["WAH"]="Active workspace height"
+      desc["WAN"]="Active workspace name"
+      desc["WAN"]="Target workspace name"
 
 
       defaults["LD1"]="A"
@@ -118,9 +120,11 @@ printlist(){
     }
 
     $1=="\"window\"" {curwid=$2}
+    $1=="\"name\"" {curnam=$2}
 
     $1=="\"num\"" {
       curws=$2
+      curwsnam=curnam
       if(workspace["WSF"]=="chk"){
         workspace["WSF"]=curws}
       if (wsdchk=="2") {
@@ -150,12 +154,14 @@ printlist(){
     trg==0 && $(NF-1) ~ crit && $NF ~ srch {
       target["TWC"]=curcid
       workspace["WST"]=curws
+      workspace["WTN"]=curwsnam
       trg=1
     }
 
     act==0 && $1=="\"focused\"" && $2=="true" {
       active["AWC"]=curcid
       workspace["WSA"]=curws
+      workspace["WAN"]=curwsnam
       workspace["WAW"]=dim[curws]["w"]
       workspace["WAH"]=dim[curws]["h"]
       act=1

--- a/i3run/i3run
+++ b/i3run/i3run
@@ -47,6 +47,7 @@ main(){
 }
 
 launchcommand(){
+  # notify-send "$command"
   eval "${command}" > /dev/null 2>&1 & 
 
   [[ -n $oldname ]] && {
@@ -103,13 +104,13 @@ focuswindow(){
       if [[ ${i3list[WSA]} != "${i3list[WST]}" ]]; then
         if [[ ${i3list[WST]} = "-1" ]] || [[ $summon = 1 ]]; then
           i3-msg -q "[con_id=${i3list[TWC]}]" \
-            move to workspace "${i3list[WSA]}", \
+            move to workspace "${i3list[WAN]}", \
             floating $fs
             i3-msg -q "[con_id=${i3list[TWC]}]" focus
             ((i3list[TWF] == 1)) && ((followmouse == 1)) \
               && sendtomouse
         else
-          i3-msg -q workspace "${i3list[WST]}"
+          i3-msg -q workspace "${i3list[WTN]}"
         fi
         
       fi
@@ -125,12 +126,12 @@ focuswindow(){
           # current ws is not i3fyra WS
           if [[ ${i3list[WST]} = "-1" ]] || [[ $summon = 1 ]]; then
             i3-msg -q "[con_id=${i3list[TWC]}]" \
-              move to workspace "${i3list[WSA]}", floating $fs
+              move to workspace "${i3list[WAN]}", floating $fs
               i3-msg -q "[con_id=${i3list[TWC]}]" focus
               ((i3list[TWF] == 1)) && ((followmouse == 1)) \
                 && sendtomouse
           else
-            i3-msg -q workspace "${i3list[WST]}"
+            i3-msg -q workspace "${i3list[WTN]}"
           fi
         fi
       fi


### PR DESCRIPTION
i think this will fix the bug with extra workspaces created when using i3run to summon a window from the scratchpad #10 