### PR TITLE
[FIX] fixed issue where empty workspaces didnt behave.

### DIFF
--- a/src/i3list
+++ b/src/i3list
@@ -3,7 +3,7 @@
 ___printversion(){
   
 cat << 'EOB' >&2
-i3list - version: 0.3
+i3list - version: 0.33
 updated: 2021-05-28 by budRich
 EOB
 }
@@ -47,10 +47,6 @@ main(){
 
   
 }
-
-
-
-
 
 ___printhelp(){
   
@@ -292,27 +288,35 @@ END {
   for (target in at) {
     id=at[target]
     if (id) {
-      print_window(target,id)
-      print ""
+      # if its not a con it is probably a workspace
+      # dont print window info on that id
+      if (ac[id]["type"] == "\"con\"")
+      {
+        print_window(target,id)
+        print ""
 
-      if (i3fyra_workspace_id) {
+        if (i3fyra_workspace_id) {
 
-        parent_id=ac[id]["parent"]
-        awp=ac[parent_id]["i3fyra_mark"]
-        grand_parent_id=ac[parent_id]["parent"]
-        gwp=ac[grand_parent_id]["i3fyra_mark"]
+          parent_id=ac[id]["parent"]
+          awp=ac[parent_id]["i3fyra_mark"]
+          grand_parent_id=ac[parent_id]["parent"]
+          gwp=ac[grand_parent_id]["i3fyra_mark"]
 
-        if (awp) {
-          print_fyra_window(target,id,awp)
-          print ""
-        } else if (gwp) {
-          print_fyra_window(target,id,gwp)
-          print ""
+          if (awp) {
+            print_fyra_window(target,id,awp)
+            print ""
+          } else if (gwp) {
+            print_fyra_window(target,id,gwp)
+            print ""
+          }
+
         }
-
       }
 
-      print_workspace(target,ac[id]["workspace"])
+      if (target == "A" || target_container_id == active_container_id)
+        print_workspace(target,active_workspace_id)
+      else
+        print_workspace(target,ac[id]["workspace"])
       print ""
     }
   }
@@ -464,7 +468,10 @@ $(NF-1) ~ /"(type|id|window|name|num|x|floating|marks|layout|focused|instance|cl
     case "focused":
       if ($NF == "true") {
         active_container_id=cid
-        active_workspace_id=cwsid
+        if (ac[cid]["type"] == "\"workspace\"")
+          active_workspace_id=cid
+        else
+          active_workspace_id=cwsid
       }
       ac[cid]["workspace"]=cwsid
       ac[cid]["parent"]=current_parent_id


### PR DESCRIPTION
the issue was that when only the workspace is active, the active container itself
is the workspace. This is now handled correctly.

Also made sure not to print any container info if this (empty workspace) is the case.

This fixes #99 