### PR TITLE
[FIX] floating state was sometimes wrong when windows being sent across workspaces.

### DIFF
--- a/src/i3run
+++ b/src/i3run
@@ -3,11 +3,17 @@
 ___printversion(){
   
 cat << 'EOB' >&2
-i3run - version: 0.1
+i3run - version: 0.12
 updated: 2021-05-28 by budRich
 EOB
 }
 
+
+# environment variables
+: "${I3RUN_BOTTOM_GAP:=10}"
+: "${I3RUN_TOP_GAP:=10}"
+: "${I3RUN_LEFT_GAP:=10}"
+: "${I3RUN_RIGHT_GAP:=10}"
 
 
 main(){
@@ -148,7 +154,8 @@ ERH(){
 
 focuswindow(){
 
-  declare -i forcing hvar
+  declare -i forcing
+  local hvar
 
   forcing=$((__o[FORCE] ? 2 : __o[force] ? 1 : 0))
   


### PR DESCRIPTION
This was due to a variable (hvar) being declared as an int, later in the program i tested if hvar was empty.
since the default value for int in bash is 0, that test alwasy passed. Fixed by changing type to normal var.

Fixes github issue #99

---
also fixed a template bug so that environment variables are now included.