### PR TITLE
[FIX] named workspaces dont have numbers

### DIFF
--- a/src/i3run
+++ b/src/i3run
@@ -18,28 +18,46 @@ EOB
 
 main(){
 
-  declare -a acri   # options passed to i3list/i3get
-  declare -A i3list # globals array
+  declare -a acri       # options passed to i3list/i3get
+  declare -A i3list     # globals array
+  declare -g _msgstring # passed to i3-msg ( messy() )
+
+  ((__o[verbose])) && {
+    _t=$(( 10#${EPOCHREALTIME//[!0-9]} ))
+    ERM "i3run START"
+    ERM "==========="
+  }
 
   for k in instance class title conid winid; do
-    [[ -n ${__o[$k]} ]] \
-      && acri+=("--$k" "${__o[$k]}")
+    [[ ${__o[$k]} ]] || continue
+    acri+=("--$k" "${__o[$k]}")
   done ; unset k
 
   [[ -z ${acri[*]} ]] \
     && ERH "please specify a criteria"
 
+  ((__o[verbose])) && ERM "i3run -> i3list ${acri[*]}"
   _array=$(i3list "${acri[@]}")
   eval "$_array"
 
   _command=${__o[command]:-$*}
+  kk=ll
 
   # if window doesn't exist, launch the command.
   if [[ -z ${i3list[TWC]} ]]; then
-    launchcommand "$@"
+    launchcommand
   else
-    focuswindow "$@"
+    focuswindow
   fi
+
+  ((__o[verbose])) || qflag=-q
+  [[ $_msgstring ]] && i3-msg ${qflag:-} "$_msgstring"
+
+  ((__o[verbose])) && {
+    ERM "======================"
+    ERM "i3run STOP - $(( (10#${EPOCHREALTIME//[!0-9]} - _t) / 1000 ))ms"
+    ERM "======================"
+  } 
 }
 
 ___printhelp(){
@@ -50,7 +68,7 @@ i3run - Run, Raise or hide windows in i3wm
 
 SYNOPSIS
 --------
-i3run --instance|-i INSTANCE  [--summon|-s] [--nohide|-g]
+i3run --instance|-i INSTANCE  [--summon|-s] [--nohide|-g] [--verbose]
 i3run --class|-c    CLASS     [--rename|-x OLD_NAME] 
 i3run --title|-t    TITLE     [--rename-instance OLD_NAME] [--rename-class OLD_NAME] [--rename-title OLD_NAME]
 i3run --conid|-n    CON_ID    [--force|-f] [--FORCE|-F] 
@@ -72,6 +90,10 @@ current workspace
 
 --nohide|-g  
 Don't hide window/container if it's active.
+
+
+--verbose  
+More stuff is printed to stderr
 
 
 --class|-c CLASS  
@@ -209,23 +231,20 @@ focuswindow(){
     if ((!__o[nohide])); then
       if [[ -z ${i3list[TWP]} ]]; then
         # keep floating state in a var
-        i3-msg -q "[con_id=${i3list[TWC]}]" move scratchpad
+        messy "[con_id=${i3list[TWC]}]" floating enable, move scratchpad
         i3var set "hidden${i3list[TWC]}" "${i3list[TWF]}"
       else
         # if it is handled by i3fyra and active
         # hide the container
-        i3fyra --force --hide "${i3list[TWP]}" --array "$_array"
+        ((__o[verbose])) && ERM "i3run -> i3fyra --force --hide ${i3list[TWP]}"
+        i3fyra "${__o[verbose]:+--verbose}" --array "$_array" --force --hide "${i3list[TWP]}"
       fi
 
-     ((forcing == 2)) && [[ $_command ]] && {
-       eval "$_command" > /dev/null 2>&1 & 
-     }
+     ((forcing == 2)) && [[ $_command ]] && run_command
 
     else
 
-     ((forcing > 0)) && [[ $_command ]] && {
-       eval "$_command" > /dev/null 2>&1 & 
-     } 
+     ((forcing > 0)) && [[ $_command ]] && run_command
     fi
 
   else # focus target window.
@@ -241,47 +260,49 @@ focuswindow(){
       ((i3list[TWF] == 1)) && fs=enable || fs=disable
     fi
     
-    if [[ -z ${i3list[TWP]} && ${i3list[WSA]} != "${i3list[WST]}" ]]; then
+    if [[ -z ${i3list[TWP]} && ${i3list[WAN]} != "${i3list[WTN]}" ]]; then
       # target is not handled by i3fyra and not active
       # TWP - target window parent container name
       # target is not on active workspace
-
-      # WST == -1 , target window is on scratchpad
-      if ((i3list[WST] == -1 || __o[summon])); then
-        i3-msg -q "[con_id=${i3list[TWC]}]"   \
+      if [[ ${i3list[WTN]} = __i3_scratch || ${__o[summon]} ]]; then
+        ERM here we are
+        messy "[con_id=${i3list[TWC]}]"   \
           move to workspace "${i3list[WAN]}", \
           floating $fs
           ((i3list[TWF] && __o[mouse])) && sendtomouse
       else
-        i3-msg -q workspace "${i3list[WTN]}"
+        messy workspace "${i3list[WTN]}"
       fi
         
-    elif ((i3list[WSA] != i3list[WST])); then
+    elif [[ ${i3list[WAN]} != "${i3list[WTN]}" ]]; then
       # window is handled by i3fyra and not active
       # current ws is i3fyra WS
       if ((i3list[WSF] == i3list[WSA])); then
         # target window is in a hidden (LHI) container
-        [[ ${i3list[TWP]} =~ [${i3list[LHI]}] ]] \
-          && i3fyra --force --show "${i3list[TWP]}" --array "$_array"
+        [[ ${i3list[TWP]} =~ [${i3list[LHI]}] ]] && {
+          ((__o[verbose])) && ERM "i3run -> i3fyra --force --show ${i3list[TWP]}"
+          i3fyra "${__o[verbose]:+--verbose}" --array "$_array" --force --show "${i3list[TWP]}"
+        }
 
       else # current ws is not i3fyra WS
         # WST == -1 , target window is on scratchpad
-        if ((i3list[WST] == -1 || __o[summon])); then
-          i3-msg -q "[con_id=${i3list[TWC]}]" \
-            move to workspace "${i3list[WAN]}", floating $fs
-            ((i3list[TWF] && __o[mouse])) && sendtomouse
+        if [[ ${i3list[WTN]} = __i3_scratch || ${__o[summon]} ]]; then
+
+          messy "[con_id=${i3list[TWC]}]"           \
+                move to workspace "${i3list[WAN]}", \
+                floating $fs
+
+          ((hvar && __o[mouse])) && sendtomouse
         else # got to target windows workspace
           # WTN == name (string) of workspace
-          i3-msg -q workspace "${i3list[WTN]}"
+          messy workspace "${i3list[WTN]}"
         fi
       fi
     fi
 
-    i3-msg -q "[con_id=${i3list[TWC]}]" focus
+    messy "[con_id=${i3list[TWC]}]" focus
 
-   ((forcing > 0)) && [[ $_command ]] && {
-     eval "$_command" > /dev/null 2>&1 & 
-   }
+   ((forcing > 0)) && [[ $_command ]] && run_command
   fi
 
   echo "${i3list[TWC]}"
@@ -293,7 +314,7 @@ launchcommand(){
   declare -a xdtopt got
 
   if [[ $_command ]]; then
-    eval "$_command" > /dev/null 2>&1 &
+    run_command
   else
     ERX i3run no command, no action
   fi
@@ -336,6 +357,9 @@ launchcommand(){
     mapfile -t got <<< "$(i3get "${acri[@]}" -yr dn)"
     read -rs winid conid <<< "${got[@]}"
 
+    ((__o[verbose])) \
+      && ERM "i3run -> xdotool set_window ${xdtopt[*]} $winid"
+      
     xdotool \
       set_window "${xdtopt[@]}" "$winid"       \
       set_window --overrideredirect 1 "$winid" \
@@ -348,8 +372,18 @@ launchcommand(){
   
   ((__o[mouse])) && sendtomouse
 
-  i3-msg -q "[con_id=$conid]" focus
+  messy "[con_id=$conid]" focus
   echo "$conid"
+}
+
+messy() {
+  (( __o[verbose] )) && ERM "m $*"
+  (( __o[dryrun]  )) || _msgstring+="$*;"
+}
+
+run_command() {
+  ((__o[verbose])) && ERM "i3run -> $_command"
+  eval "$_command" > /dev/null 2>&1 &
 }
 
 sendtomouse(){
@@ -357,7 +391,7 @@ sendtomouse(){
 
   eval "$(i3list "${acri[@]}")"
 
-  i3-msg -q "[con_id=${i3list[TWC]}]" focus
+  messy "[con_id=${i3list[TWC]}]" focus
 
   ((i3list[TWF])) && {
     breaky=$((i3list[WAH]-(I3RUN_BOTTOM_GAP+i3list[TWH])))
@@ -384,7 +418,7 @@ sendtomouse(){
               ? breakx 
               : tmpx))
 
-    i3-msg -q "[con_id=${i3list[TWC]}]" \
+    messy "[con_id=${i3list[TWC]}]" \
       move absolute position $newx $newy
   }
 }
@@ -393,7 +427,7 @@ declare -A __o
 options="$(
   getopt --name "[ERROR]:i3run" \
     --options "i:sgc:x:t:n:fFd:e:mhv" \
-    --longoptions "instance:,summon,nohide,class:,rename:,title:,rename-instance:,rename-class:,rename-title:,conid:,force,FORCE,winid:,command:,mouse,help,version," \
+    --longoptions "instance:,summon,nohide,verbose,class:,rename:,title:,rename-instance:,rename-class:,rename-title:,conid:,force,FORCE,winid:,command:,mouse,help,version," \
     -- "$@" || exit 98
 )"
 
@@ -405,6 +439,7 @@ while true; do
     --instance   | -i ) __o[instance]="${2:-}" ; shift ;;
     --summon     | -s ) __o[summon]=1 ;; 
     --nohide     | -g ) __o[nohide]=1 ;; 
+    --verbose    ) __o[verbose]=1 ;; 
     --class      | -c ) __o[class]="${2:-}" ; shift ;;
     --rename     | -x ) __o[rename]="${2:-}" ; shift ;;
     --title      | -t ) __o[title]="${2:-}" ; shift ;;


### PR DESCRIPTION
If a workspace is named with out a integer prefix it will always have the
number "-1". Before this commit i thought "-1" always meant the scratchpad
workspace. I also added --verbose option and lots of verbose messages.