### PR TITLE
I3FYRA_MAIN_CONTAINER had no effect

### DIFF
--- a/src/i3fyra/func/float_toggle.sh
+++ b/src/i3fyra/func/float_toggle.sh
@@ -30,7 +30,7 @@ float_toggle(){
     fi
     
 
-    if [[ ${i3list[LVI]} =~ I3FYRA_MAIN_CONTAINER ]]; then
+    if [[ ${i3list[LVI]} =~ $I3FYRA_MAIN_CONTAINER ]]; then
       target=$I3FYRA_MAIN_CONTAINER
     elif [[ ${i3list[LVI]} ]]; then
       target=${i3list[LVI]:0:1}

--- a/src/i3fyra/func/float_toggle.sh
+++ b/src/i3fyra/func/float_toggle.sh
@@ -10,7 +10,6 @@ float_toggle(){
   if ((i3list[AWF]==1)); then
 
     [[ -f $I3_KING_PID_FILE ]] && {
-      ERM "hhh"
 
       mapfile -t king_commands <<< "$(i3king --conid "${i3list[TWC]}" --print-commands)"
 

--- a/src/i3king/func/match_window.sh
+++ b/src/i3king/func/match_window.sh
@@ -5,6 +5,8 @@ match_window() {
   local cid=$1 class=$2 instance=$3 title=$4 
   local type=$5 role=$6 wid=$7 change=$8
 
+  ((_o[print-commands])) && change=new
+
   local last_cmd cmd rule
   local title_regex title_options new_title
 

--- a/src/i3king/func/match_window.sh
+++ b/src/i3king/func/match_window.sh
@@ -178,8 +178,7 @@ match_window() {
       ((_o[print-commands] || _o[dryrun])) \
         || >&2 i3-msg "${prefix:-} $cmd"
 
-      ((_o[print-commands])) \
-        && echo "${prefix:-} $cmd"
+      ((_o[print-commands])) && echo "${prefix:-} $cmd"
       
     done
   }

--- a/src/i3king/func/parse_rules.sh
+++ b/src/i3king/func/parse_rules.sh
@@ -88,7 +88,7 @@ parse_rules() {
           rule=${rule/$key${_fs}\[^${_fs}]\*${_fs}/$key${_fs}$val${_fs}}
         done
 
-        [[ -a $_file_log ]] && {
+        [[ -a $_file_log && -z ${_o[print-commands]} ]] && {
           rule_out=${rule//$_fs/:}
           rule_out=${rule_out//\[^:]/.}
           echo "$rule_out" 


### PR DESCRIPTION
This PR fixes two issues related to `i3fyra --float` .  
1. I3FYRA_MAIN_CONTAINER was ignored, this was due to a simple typo (missing $)
2. i3king was supposed to give i3fyra a command if a rule was set for the window.
    but it didn't because there where no *change*, so we fake a "new" change now.