### PR TITLE
Fix for i3list[WFN] not always being quoted

### DIFF
--- a/share/main.awk
+++ b/share/main.awk
@@ -28,7 +28,7 @@ $1 ~ /"(name|title_format)"/ {
 
   else if (ac[cid]["type"] == "\"workspace\"") {
 
-    if ($NF == "\"" i3fyra_workspace_name "\"")
+    if ($NF == i3fyra_workspace_name)
       i3fyra_workspace_id = cid
 
     else if ($NF == "\"__i3_scratch\"")
@@ -275,7 +275,7 @@ $(NF-1) ~ /"(class|current_border_width|floating|focus|focused|fullscreen_mode|i
           match($0,/"(i3viswiz|i34)?([^"=]+)=([^"]*)"([]])?$/,ma)
 
           if (ma[2] == "i3fyra_ws")
-            i3fyra_workspace_name=ma[3]
+            i3fyra_workspace_name = "\"" ma[3] "\""
           else if (ma[1] == "i3viswiz")
             last_direction_id=ma[3]
           else if (ma[2] == "focus_wrap")

--- a/src/i3fyra/config.mak
+++ b/src/i3fyra/config.mak
@@ -1,5 +1,5 @@
 NAME         := i3fyra
-VERSION      := 1.4.1
+VERSION      := 1.4.2
 CREATED      := 2017-01-14
 UPDATED      := 2023-07-22
 AUTHOR       := budRich

--- a/src/i3fyra/func/initialize_globals.sh
+++ b/src/i3fyra/func/initialize_globals.sh
@@ -22,9 +22,6 @@ initialize_globals() {
       I3FYRA_WS=${i3list[WAN]}
     }
 
-    [[ $I3FYRA_WS =~ ^\" ]] \
-      || I3FYRA_WS=$(printf '"%s"' "$I3FYRA_WS")
-
     (( _o[float] && i3list[AWF]==0 )) \
       || i3var set i3fyra_ws "$I3FYRA_WS"
 

--- a/src/i3var/i3var
+++ b/src/i3var/i3var
@@ -9,7 +9,7 @@ main(){
 
   : "${json:=${_o[json]:-$(i3-msg -t get_tree)}}"
 
-  re='^\{"id":([0-9]+)[^[]+\[([^]]*"'"${variable_name}"'=([^,]*)"[^]]*)?'
+  re='^\{"id":([0-9]+)[^[]+\[([^]]*"'"${variable_name}"'=([^"]*)"[^]]*)?'
   [[ $json =~ $re ]] || ERX "no vars found"
 
   root_id=${BASH_REMATCH[1]}

--- a/src/i3var/i3var
+++ b/src/i3var/i3var
@@ -9,7 +9,7 @@ main(){
 
   : "${json:=${_o[json]:-$(i3-msg -t get_tree)}}"
 
-  re='^\{"id":([0-9]+)[^[]+\[([^]]*"'"${variable_name}"'=([^"]*)"[^]]*)?'
+  re='^\{"id":([0-9]+)[^[]+\[([^]]*"'"${variable_name}"'=([^,]*)"[^]]*)?'
   [[ $json =~ $re ]] || ERX "no vars found"
 
   root_id=${BASH_REMATCH[1]}


### PR DESCRIPTION
This PR fixes a issue where the workspace name of i3fyra was not padded with doublequotes when the name was known but not the container id.

It also removes auto padding the value with `\"` when it was automatically set from i3fyra, which resulted in incorrect output with `i3var get i3fyra_ws`