### PR TITLE
2025.12.27.1 Release

### DIFF
--- a/docs/releasenotes/0next.md
+++ b/docs/releasenotes/0next.md
@@ -3,6 +3,9 @@ Monocle mode toggle. Will keep if it doesn't break too much stuff.
 Some of the logic regarding "family memory" relating to split memory
 was changed. I have not noticed anything broken, yet.
 
+## support for i3fyra --orientation toggle
+(#218 @1ntronaut )
+
 
 ## i3king GLOBAL/DEFAULT rules without a criteria
 was never parsed. big thanks to @TimRegeant && @1ntronaut

--- a/docs/releasenotes/0next.md
+++ b/docs/releasenotes/0next.md
@@ -1,17 +1,1 @@
-## experimenta i3fyra --mono 
-Monocle mode toggle. Will keep if it doesn't break too much stuff.
-Some of the logic regarding "family memory" relating to split memory
-was changed. I have not noticed anything broken, yet.
 
-## support for i3fyra --orientation toggle
-(#218 @1ntronaut )
-
-
-## i3king GLOBAL/DEFAULT rules without a criteria
-was never parsed. big thanks to @TimRegeant && @1ntronaut
-for reporting and helping out with this (#214)
-
-## Don't trigger i3king rules on float toggle on non-i3fyra workspace
-
-## i3ass command now includes i3run, i3term, i3menu and dmenu
-(#218 @1ntronaut )

--- a/docs/releasenotes/0next.md
+++ b/docs/releasenotes/0next.md
@@ -1,10 +1,5 @@
-## broken regex search now works
+## i3king GLOBAL/DEFAULT rules without a criteria
+was never parsed. big thanks to @TimRegeant && @1ntronaut
+for reporting and helping out with this (#214)
 
-fix for issue #211 .  
-Big thanks to @henryzxb for reporting
-
-Allthough small, this change affects all i3ass commands,
-except i3king. Hopefully we didn't break something.
-
-^ above fix introduced an issue with i3get without criterion
-(targeting the active window), but it is now fixed
+## Don't trigger i3king rules on float toggle on non-i3fyra workspace

--- a/docs/releasenotes/0next.md
+++ b/docs/releasenotes/0next.md
@@ -3,3 +3,6 @@ was never parsed. big thanks to @TimRegeant && @1ntronaut
 for reporting and helping out with this (#214)
 
 ## Don't trigger i3king rules on float toggle on non-i3fyra workspace
+
+## i3ass command now includes i3run, i3term, i3menu and dmenu
+(#218 @1ntronaut )

--- a/docs/releasenotes/0next.md
+++ b/docs/releasenotes/0next.md
@@ -1,3 +1,9 @@
+## experimenta i3fyra --mono 
+Monocle mode toggle. Will keep if it doesn't break too much stuff.
+Some of the logic regarding "family memory" relating to split memory
+was changed. I have not noticed anything broken, yet.
+
+
 ## i3king GLOBAL/DEFAULT rules without a criteria
 was never parsed. big thanks to @TimRegeant && @1ntronaut
 for reporting and helping out with this (#214)

--- a/docs/releasenotes/2025-12-27.md
+++ b/docs/releasenotes/2025-12-27.md
@@ -1,0 +1,29 @@
+##  i3fyra --mono 
+Monocle mode toggle. If used on i3fyra workspace
+will make currently focused fyra container the only visible.
+If it already is the only visible, this command will show
+the other containers. This includes some smart logic, so
+it remembers which windows where hidden, so toggling back and forth
+works smooth.
+
+If window is not on i3fyra workspace, this command will toggle fullscreen.
+(#225 @1ntronaut )
+
+## i3fyra --rotate family|sibling
+swaps place of families or siblings with one command.
+To achieve this before you needed to first hide the target
+then show it on the opposite direction (that still works btw)
+
+## i3fyra --orientation
+Now supports `toggle` argument  
+(#218 @1ntronaut )
+
+
+## i3king GLOBAL/DEFAULT rules without a criteria
+was never parsed. big thanks to @TimRegeant && @1ntronaut
+for reporting and helping out with this (#214)
+
+## Don't trigger i3king rules on float toggle on non-i3fyra workspace
+
+## i3ass command now includes i3run, i3term, i3menu and dmenu
+(#218 @1ntronaut )

--- a/src/i3Kornhe/i3Kornhe.1
+++ b/src/i3Kornhe/i3Kornhe.1
@@ -1,14 +1,10 @@
 .nh
-.TH I3KORNHE   2023-07-22 budlabs "User Manuals"
+.TH I3KORNHE   2024-04-21 budlabs "User Manuals"
 .SH NAME
-.PP
-i3Kornhe - move and resize windows gracefully
+i3Kornhe \- move and resize windows gracefully
 
 .SH SYNOPSIS
-.PP
-.RS
-
-.nf
+.EX
 i3Kornhe     DIRECTION [--verbose] [--array ARRAY] [--json JSON]
 i3Kornhe     move [--speed|-p SPEED] [DIRECTION]
 i3Kornhe     size [--speed|-p SPEED] [DIRECTION]
@@ -16,15 +12,10 @@ i3Kornhe     1-9 [--margin INT] [--oneshot]
 i3Kornhe     --help|-h
 i3Kornhe     --version|-v
 i3Kornhe     x
-
-.fi
-.RE
+.EE
 
 .SH OPTIONS
-.PP
-.RS
-
-.nf
+.EX
 --array       ARRAY | use ARRAY instead of output of `i3list`  
 -h, --help          | print help and exit  
 --json        JSON  | use ARRAY instead of output of `i3-msg -t get_tree`  
@@ -33,12 +24,9 @@ i3Kornhe     x
 -p, --speed   SPEED | set step SPEED in pixels  
 --verbose           | louder output  
 -v, --version       | print version info and exit  
-
-.fi
-.RE
+.EE
 
 .SS --margin      INT
-.PP
 This is only used when
 moving a window and the direction is a number.
 INT is the number of pixels from the screen
@@ -49,7 +37,6 @@ The default value is 5 and it applies to all
 margins of the screen.
 
 .SH USAGE
-.PP
 i3Kornhe provides an alternative way to move and
 resize windows in \fBi3\fP\&. It has some more
 functions then the defaults and is more
@@ -59,18 +46,15 @@ moving that corner.
 
 .SH ENVIRONMENT
 .SS I3_KORNHE_FIFO_FILE
-.PP
 File that commands will be sent to.
 Defaults to: $XDG_RUNTIME_DIR/i3ass/i3Kornhe.fifo
 
 .SH CONTACT
-.PP
 Send bugs and feature requests to:
 .br
 https://github.com/budlabs/i3ass/issues
 
 .SH COPYRIGHT
-.PP
-Copyright (c) 2017-2023, budRich of budlabs
+Copyright (c) 2017-2025, budRich of budlabs
 .br
 SPDX-License-Identifier: MIT

--- a/src/i3ass/config.mak
+++ b/src/i3ass/config.mak
@@ -1,7 +1,7 @@
 NAME         := i3ass
-VERSION      := 2023.08.19.1
+VERSION      := 2025.03.30.1
 CREATED      := 2023-07-12
-UPDATED      := 2023-08-19
+UPDATED      := 2025-03-30
 AUTHOR       := budRich
 CONTACT      := https://github.com/budlabs/i3ass
 USAGE        := i3ass

--- a/src/i3ass/config.mak
+++ b/src/i3ass/config.mak
@@ -1,7 +1,7 @@
 NAME         := i3ass
-VERSION      := 2025.03.30.1
+VERSION      := 2025.12.27.1
 CREATED      := 2023-07-12
-UPDATED      := 2025-03-30
+UPDATED      := 2025-12-27
 AUTHOR       := budRich
 CONTACT      := https://github.com/budlabs/i3ass
 USAGE        := i3ass

--- a/src/i3ass/i3ass
+++ b/src/i3ass/i3ass
@@ -2,18 +2,24 @@
 
 main(){
 
-  for ass in i3{flip,fyra,get,gw,king,Kornhe,list,var,viswiz,zen}; do
+  for ass in i3{flip,fyra,get,gw,king,Kornhe,list,run,var,viswiz,zen,menu,term}; do
     path=$(command -v "$ass")
-    version_output=$("$ass" -v 2>&1)
+    
     
     # i3ass - version: 0.0.1
     # updated: 2023-07-12 by budRich
-    [[ $path ]] \
-      && read -rs _ _ _ version _ updated _ \
+    if [[ $path ]]; then
+      version_output=$("$ass" -v 2>&1)
+      read -rs _ _ _ version _ updated _ \
          <<< "${version_output//$'\n'/ }" 
 
-    printf "%-8s | %-7s | %-10s | %s\n" \
-      "$ass" "${version:--}" "${updated:--}" "${path/~/'~'}"
+      printf "%-8s | %-7s | %-10s | %s\n" \
+        "$ass" "${version:--}" "${updated:--}" "${path/~/'~'}"
+    else
+      printf "%-8s | MISSING! %s\n" "$ass"
+    fi
+
+    [[ $ass = i3zen ]] && echo
   done
 
   echo
@@ -21,12 +27,16 @@ main(){
   echo
 
   for cmd in i3 bash gawk xdotool ; do
-    if command -v "$cmd" >/dev/null ; then
-      "$cmd" --version 2>&- | head -n1
-    else
-      echo "WARNING: command $cmd not found"
+    if command -v "$cmd" >/dev/null
+      then "$cmd" --version 2>&- | head -n1
+      else echo "WARNING: command $cmd not found"
     fi
   done
+
+  if command -v dmenu >/dev/null
+    then dmenu -v 2>&-
+    else "WARNING: command $cmd not found"
+  fi
 
   echo
   echo -------------------------------------------

--- a/src/i3ass/i3ass.1
+++ b/src/i3ass/i3ass.1
@@ -1,42 +1,32 @@
 .nh
-.TH I3ASS   2023-08-19 budlabs "User Manuals"
+.TH I3ASS   2025-12-27 budlabs "User Manuals"
 .SH NAME
-.PP
-i3ass - Print environment information
+i3ass \- Print environment information
 
 .SH SYNOPSIS
-.PP
-\fB\fCi3ass\fR
+\fBi3ass\fR
 
 .SH OPTIONS
-.PP
-.RS
-
-.nf
+.EX
 -h, --help     | print help and exit  
 -v, --version  | print messages to stderr  
-
-.fi
-.RE
+.EE
 
 .SH USAGE
-.PP
-The \fB\fCi3ass\fR command is used to print information
+The \fBi3ass\fR command is used to print information
 about the current environment relevant to i3ass.
 The version, update date and installation path of
 the other commands in i3ass. Version of the commands
-\fB\fCi3, xdotool, gawk, bash\fR\&. And the environment variables:
+\fBi3, xdotool, gawk, bash\fR\&. And the environment variables:
 .br
 I3FYRA_WS and I3FYRA_MAIN_CONTAINER.
 
 .SH CONTACT
-.PP
 Send bugs and feature requests to:
 .br
 https://github.com/budlabs/i3ass/issues
 
 .SH COPYRIGHT
-.PP
-Copyright (c) 2023, budRich of budlabs
+Copyright (c) 2023-2025, budRich of budlabs
 .br
 SPDX-License-Identifier: MIT

--- a/src/i3flip/i3flip.1
+++ b/src/i3flip/i3flip.1
@@ -1,32 +1,25 @@
 .nh
-.TH I3FLIP   2023-08-13 budlabs "User Manuals"
+.TH I3FLIP   2024-04-21 budlabs "User Manuals"
 .SH NAME
-.PP
-i3flip - Tabswitching done right
+i3flip \- Tabswitching done right
 
 .SH SYNOPSIS
-.PP
-\fB\fCi3flip [--move|-m] DIRECTION\fR
+\fBi3flip [--move|-m] DIRECTION\fR
 
 .SH OPTIONS
-.PP
-.RS
-
-.nf
+.EX
 --dryrun           | don't execute any commands  
 -h, --help         | print help and exit  
 --json        JSON | use JSON instead of output of `i3-msg -t get_tree`  
 -m, --move         | move instead of focus shift  
 --verbose          | louder output  
 -v, --version      | print version info and exit  
-
-.fi
-.RE
+.EE
 
 .PP
-\fB\fCi3flip\fR switch containers without leaving the
+\fBi3flip\fR switch containers without leaving the
 parent. Perfect for tabbed or stacked layout, but
-works on all layouts. If direction is \fB\fCnext\fR and
+works on all layouts. If direction is \fBnext\fR and
 the active container is the last, the first
 container will get focused.
 
@@ -40,28 +33,20 @@ can be defined with different words:
 \fBprev\fP|left|up|p|l|u
 
 .SS examples
-.PP
-\fB\fC~/.config/i3/config\fR:
+\fB~/.config/i3/config\fR:
 
-.PP
-.RS
-
-.nf
+.EX
 \&...
 bindsym Mod4+Tab         exec --no-startup-id i3flip next
 bindsym Mod4+Shift+Tab   exec --no-startup-id i3flip prev
-
-.fi
-.RE
+.EE
 
 .SH CONTACT
-.PP
 Send bugs and feature requests to:
 .br
 https://github.com/budlabs/i3ass/issues
 
 .SH COPYRIGHT
-.PP
-Copyright (c) 2018-2023, budRich of budlabs
+Copyright (c) 2018-2025, budRich of budlabs
 .br
 SPDX-License-Identifier: MIT

--- a/src/i3fyra/config.mak
+++ b/src/i3fyra/config.mak
@@ -1,7 +1,7 @@
 NAME         := i3fyra
-VERSION      := 1.4.4
+VERSION      := 1.5.0
 CREATED      := 2017-01-14
-UPDATED      := 2025-03-30
+UPDATED      := 2025-12-27
 AUTHOR       := budRich
 CONTACT      := https://github.com/budlabs/i3ass
 USAGE        := options

--- a/src/i3fyra/config.mak
+++ b/src/i3fyra/config.mak
@@ -1,7 +1,7 @@
 NAME         := i3fyra
-VERSION      := 1.4.3
+VERSION      := 1.4.4
 CREATED      := 2017-01-14
-UPDATED      := 2024-04-21
+UPDATED      := 2025-03-30
 AUTHOR       := budRich
 CONTACT      := https://github.com/budlabs/i3ass
 USAGE        := options

--- a/src/i3fyra/docs/options/mono
+++ b/src/i3fyra/docs/options/mono
@@ -1,0 +1,1 @@
+toggle monocle mode 

--- a/src/i3fyra/docs/options/orientation
+++ b/src/i3fyra/docs/options/orientation
@@ -1,1 +1,1 @@
-short description  
+main split orientation on i3fyra WS (horizontal|vertical|toggle)

--- a/src/i3fyra/docs/options/rotate
+++ b/src/i3fyra/docs/options/rotate
@@ -1,0 +1,1 @@
+switch position with <sibling|family>  

--- a/src/i3fyra/func/container_hide.sh
+++ b/src/i3fyra/func/container_hide.sh
@@ -29,9 +29,12 @@ container_hide(){
 
   # if target is last of it's fam, note it.
   # else focus sibling as the last operation (main())
-  [[ ${i3list[LVI]} =~ $sibling ]]         \
-    && i3list[SIBFOC]=$sibling             \
-    || mark_vars["i34F${target_family}"]=$target
+  if [[ ${i3list[LVI]} =~ $sibling ]]; then
+    i3list[SIBFOC]=$sibling
+    mark_vars["i34F${target_family}"]=${i3list[F${target_family}]/$target/}
+  else
+    mark_vars["i34F${target_family}"]=$target
+  fi
 
   # note splits
   ((split_main && split_main != ori[sizemain])) && {

--- a/src/i3fyra/func/container_hide.sh
+++ b/src/i3fyra/func/container_hide.sh
@@ -40,8 +40,11 @@ container_hide(){
   ((split_main && split_main != ori[sizemain])) && {
     mark_vars["i34M${ori[main]}"]=$split_main
     i3list[M${main}]=$split_main
+    
+  }
+
+  ((split_family && split_family != ori[sizefam])) && {
     mark_vars["i34M${target_family}"]=$split_family
     i3list[M${target_family}]=$split_family
   }
-
 }

--- a/src/i3fyra/func/family_create.sh
+++ b/src/i3fyra/func/family_create.sh
@@ -17,15 +17,14 @@ family_create() {
       focus, focus parent
     messy mark "i34X$target_family"
   else
+    
     messy "[con_mark=i34$target_container]" \
       move --no-auto-back-and-forth to workspace "${i3list[WFN]}", \
       floating disable, \
       layout "split${ori[charfam]}", \
       focus, focus parent
     messy mark "i34X$target_family"
-    messy "[con_mark=i34X$target_family]" \
-      layout "split${ori[charmain]}", \
-      focus, focus parent
-    messy mark "i34X${ori[main]}"
+    
+    main_create "$target_family"
   fi
 }

--- a/src/i3fyra/func/family_show.sh
+++ b/src/i3fyra/func/family_show.sh
@@ -40,10 +40,7 @@ family_show() {
         move to mark "i34X${ori[main]}"
 
     else
-      messy "[con_mark=i34X${target_family}]" \
-        layout split"${ori[charmain]}", \
-        focus, focus parent
-      messy mark "i34X${ori[main]}"
+      main_create "${target_family}"
     fi
   fi
 

--- a/src/i3fyra/func/float_toggle.sh
+++ b/src/i3fyra/func/float_toggle.sh
@@ -9,10 +9,16 @@ float_toggle(){
   # AWF - 1 = floating; 0 = tiled
   if ((i3list[AWF]==1)); then
 
-    [[ -f $I3_KING_PID_FILE ]] && {
+    # WSA != i3fyra && normal tiling
+    if [[ ${i3list[WAN]} != "${i3list[WFN]}" ]]; then
+      messy "[con_id=${i3list[AWC]}]" floating disable
+      return
 
+    # only on fyra WS, if i3king rule for window
+    # exist that doesn't do: "floating enable",
+    # execute that rule and return
+    elif [[ -f $I3_KING_PID_FILE ]]; then
       mapfile -t king_commands <<< "$(i3king --conid "${i3list[TWC]}" --print-commands)"
-
       for command in "${!king_commands[@]}"; do
         if [[ ${king_commands[command]} =~ floating\ enable ]]
           then unset 'king_commands[command]'
@@ -21,12 +27,6 @@ float_toggle(){
       done
 
       [[ ${king_commands[*]} ]] && return
-    }
-
-    # WSA != i3fyra && normal tiling
-    if [[ ${i3list[WAN]} != "${i3list[WFN]}" ]]; then
-      messy "[con_id=${i3list[AWC]}]" floating disable
-      return
     fi
     
 

--- a/src/i3fyra/func/float_toggle.sh
+++ b/src/i3fyra/func/float_toggle.sh
@@ -40,7 +40,7 @@ float_toggle(){
       target=$I3FYRA_MAIN_CONTAINER
     fi
 
-     if [[ ${i3list[LEX]} =~ $target ]]; then
+    if [[ ${i3list[LEX]} =~ $target ]]; then
       container_show "$target"
       messy "[con_id=${i3list[AWC]}]" floating disable, \
         move to mark "i34${target}"

--- a/src/i3fyra/func/initialize_globals.sh
+++ b/src/i3fyra/func/initialize_globals.sh
@@ -31,6 +31,7 @@ initialize_globals() {
 
     ((_o[verbose])) && ERM INIT FYRA_ORIENTATION
 
+    : "${I3FYRA_ORIENTATION:-horizontal}"
     i3var set i34ORI "${_o[orientation]:-$I3FYRA_ORIENTATION}"
   }
 

--- a/src/i3fyra/func/main_create.sh
+++ b/src/i3fyra/func/main_create.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+main_create() {
+
+  ((_o[verbose])) && ERM "f ${FUNCNAME[0]}($*)"
+
+  local creating_family=$1
+
+  [[ ${i3list["X${ori[main]}"]} ]] || {
+    
+    [[ $creating_family =~ [ABCD]{1,2} ]] \
+      || ERX "cannot create layout, invalid family: '${creating_family}'"
+
+    messy "[con_mark=i34X${creating_family}]" \
+      layout split"${ori[charmain]}", \
+      focus, focus parent
+    messy mark "i34X${ori[main]}"
+
+    i3list["X${ori[main]}"]=${i3list[WSF]}
+  }
+}

--- a/src/i3fyra/func/monocle.sh
+++ b/src/i3fyra/func/monocle.sh
@@ -4,7 +4,7 @@
 monocle_toggle() {
 
   ((i3list[WSA] == i3list[WSF])) || {
-    ERM "mono operation only possible on with i3fyra workspace"
+    ERM "mono operation only possible on i3fyra workspace"
     return
   }
 

--- a/src/i3fyra/func/monocle.sh
+++ b/src/i3fyra/func/monocle.sh
@@ -5,6 +5,7 @@ monocle_toggle() {
 
   ((i3list[WSA] == i3list[WSF])) || {
     ERM "mono operation only possible on i3fyra workspace"
+    messy fullscreen toggle
     return
   }
 

--- a/src/i3fyra/func/monocle.sh
+++ b/src/i3fyra/func/monocle.sh
@@ -16,6 +16,7 @@ monocle_toggle() {
       || to_show=${i3list[LEX]}
     
     multi_show "$to_show"
+    messy "[con_id=${i3list[AWC]}]" focus
   else
     multi_hide "${i3list[LVI]/${i3list[AWP]}/}"
   fi

--- a/src/i3fyra/func/monocle.sh
+++ b/src/i3fyra/func/monocle.sh
@@ -9,7 +9,32 @@ monocle_toggle() {
     return
   }
 
-  if ((${#i3list[LVI]} < 2)); then
+  # AWF == 1, active window is floating
+  if ((i3list[AWF]==1)); then
+
+    if [[ ${i3list[LVI]} =~ $I3FYRA_MAIN_CONTAINER ]]; then
+      target=$I3FYRA_MAIN_CONTAINER
+    elif [[ ${i3list[LVI]} ]]; then
+      target=${i3list[LVI]:0:1}
+    elif [[ ${i3list[LHI]} ]]; then
+      target=${i3list[LHI]:0:1}
+    else
+      target=$I3FYRA_MAIN_CONTAINER
+    fi
+
+    if [[ ${i3list[LEX]} =~ $target ]]; then
+      container_show "$target"
+      messy "[con_id=${i3list[AWC]}]" floating disable, \
+        move to mark "i34${target}"
+    else
+      # if $target container doesn't exist, create it
+      container_show "$target"
+    fi
+
+    to_hide="${i3list[LVI]/$target/}"
+    [[ $to_hide ]] && multi_hide "$to_hide"
+
+  elif ((${#i3list[LVI]} < 2)); then
     # use family memory if it exist
     last_seen="${i3list[F${ori[fam1]}]}${i3list[F${ori[fam2]}]}"
     [[ $last_seen ]] \

--- a/src/i3fyra/func/monocle.sh
+++ b/src/i3fyra/func/monocle.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# https://github.com/budlabs/i3ass/issues/225
+monocle_toggle() {
+
+  ((i3list[WSA] == i3list[WSF])) || {
+    ERM "mono operation only possible on with i3fyra workspace"
+    return
+  }
+
+  if ((${#i3list[LVI]} < 2)); then
+    # use family memory if it exist
+    last_seen="${i3list[F${ori[fam1]}]}${i3list[F${ori[fam2]}]}"
+    [[ $last_seen ]] \
+      && to_show=$last_seen \
+      || to_show=${i3list[LEX]}
+    
+    multi_show "$to_show"
+  else
+    multi_hide "${i3list[LVI]/${i3list[AWP]}/}"
+  fi
+}

--- a/src/i3fyra/func/multi_hide.sh
+++ b/src/i3fyra/func/multi_hide.sh
@@ -23,6 +23,13 @@ multi_hide(){
 
   # hide rest if any
   ((${#trgs})) && for ((i=0;i<${#trgs};i++)); do
-    container_hide "${trgs:$i:1}"
+    single=${trgs:$i:1}
+    container_hide "$single"
+
+    # setting the family memory to the single hidden
+    # container, let us restore with --mono
+    [[ $f1 =~ $single ]] \
+      && mark_vars["i34F${f1}"]=$single \
+      || mark_vars["i34F${f2}"]=$single
   done
 }

--- a/src/i3fyra/func/multi_show.sh
+++ b/src/i3fyra/func/multi_show.sh
@@ -9,7 +9,21 @@ multi_show(){
   # only show hidden containers in arg
   for (( i = 0; i < ${#arg}; i++ )); do
     trg=${arg:$i:1}
-    [[ ${i3list[LHI]} =~ $trg ]] \
-      && container_show "$trg"
+    [[ ${i3list[LHI]} =~ $trg ]] && trgs+=$trg
+  done
+
+  ((${#trgs})) || return
+
+  # show whole families if present in arg and hidden
+  [[ $trgs =~ ${f1:0:1} && $trgs =~ ${f1:1:1} ]] \
+    && trgs=${trgs//[$f1]/} && family_show "$f1"
+  
+  [[ $trgs =~ ${f2:0:1} && $trgs =~ ${f2:1:1} ]] \
+    && trgs=${trgs//[$f2]/} && family_show "$f2"
+
+  # show rest if any
+  ((${#trgs})) && for ((i=0;i<${#trgs};i++)); do
+    single=${trgs:$i:1}
+    container_show "$single"
   done
 }

--- a/src/i3fyra/func/orientation.sh
+++ b/src/i3fyra/func/orientation.sh
@@ -6,6 +6,13 @@ orientation() {
   local old_orientation=${i3list[ORI]}
   local i container
 
+  [[ $new_orientation = toggle ]] && {
+    if [[ $old_orientation = vertical ]]
+      then new_orientation=horizontal
+      else new_orientation=vertical
+    fi
+  }
+
   [[ $new_orientation = "$old_orientation" ]] && return
 
   declare -A new_ori

--- a/src/i3fyra/func/rotate.sh
+++ b/src/i3fyra/func/rotate.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# --rotate sibling|family
+rotate() {
+  target=$1
+
+  if [[ $target = family && ${i3list[AFO]} =~ [${i3list[LVI]}] ]]
+    then swap_move "i34X${ori[fam1]}" "i34X${ori[fam2]}"
+  elif [[ $target = sibling && ${i3list[AFS]} =~ [${i3list[LVI]}] ]]
+    then swap_move "i34${i3list[AWP]}" "i34${i3list[AFS]}"
+  fi
+}  

--- a/src/i3fyra/func/swap_move.sh
+++ b/src/i3fyra/func/swap_move.sh
@@ -27,8 +27,6 @@ swap_move(){
     ik_current[current_val]=$k
   done
 
-   ERM "${ik_current[*]} LLLLLLLL"
-
   # family marks always contain 'X'
   # when we swap families all virtual positions
   # are swapped
@@ -45,7 +43,6 @@ swap_move(){
     mark_vars[i34M${ori[fam1]}]=${i3list[M${ori[fam2]}]}
     mark_vars[i34M${ori[fam2]}]=${i3list[M${ori[fam1]}]}
 
-    ERM "VPA=${i3list[VPA]}; VPB=${i3list[VPB]}; VPC=${i3list[VPC]}; VPD=${i3list[VPD]}"
     for k in A B C D; do
 
       c1=${k}                     c2=${ck_target[$k]}

--- a/src/i3fyra/func/varset.sh
+++ b/src/i3fyra/func/varset.sh
@@ -7,20 +7,20 @@ varset() {
   local key val re  current_value
 
   for key in "${!mark_vars[@]}"; do
-    unset current_value
+    unset current_value old_mark
     val=${mark_vars[$key]}
+    re="\"${key}=([^\",]*)\""
 
-    re="\"${key}=([^\"]*)\""
-
-    [[ $_marks_json =~ $re ]] && current_value=${BASH_REMATCH[1]}
-
-    [[ $current_value = "$val" ]] && continue
+    [[ $_marks_json =~ $re ]] && {
+      current_value=${BASH_REMATCH[1]}
+      old_mark="${key}=$current_value"
+      [[ $val && $current_value = "$val" ]] && continue
+    }
 
     new_mark="${key}=$val"
-    old_mark="${key}=$current_value"
-
+    
     # this will remove the old mark
-    [[ $current_value ]] \
+    [[ $old_mark ]] \
       && messy "[con_id=${i3list[RID]}] mark --toggle --add $old_mark"
 
     messy "[con_id=${i3list[RID]}] mark --add $new_mark"

--- a/src/i3fyra/i3fyra
+++ b/src/i3fyra/i3fyra
@@ -15,7 +15,7 @@ main(){
     exit
   }
 
-  for _action in move show hide layout float orientation; do
+  for _action in move show hide layout float orientation mono; do
     
     [[ ${arg:=${_o[$_action]}} ]] || continue
     err="i3fyra: argument for '--$_action': '$arg' not valid!"
@@ -29,7 +29,6 @@ main(){
       show|hide ) [[ $arg =~ ^[ABCD]+$ ]] || ERX "$err expected (A|B|C|D)" ;;
       layout    ) [[ $arg =~ = || $arg = redo ]] || ERX "$err"             ;;
       float     ) (($#)) && ERX "$err expected 0 arguments got '($*)'"     ;;
-
       orientation )
         ex="vertical|horizontal"
         [[ $arg =~ ${ex} ]] || ERX "$err expected ($ex)" 
@@ -61,6 +60,7 @@ main(){
     layout      ) apply_splits "$arg"   ;;
     float       ) float_toggle          ;;
     orientation ) orientation "$arg"    ;;
+    mono        ) monocle_toggle        ;;
 
   esac
 

--- a/src/i3fyra/i3fyra
+++ b/src/i3fyra/i3fyra
@@ -30,7 +30,7 @@ main(){
       layout    ) [[ $arg =~ = || $arg = redo ]] || ERX "$err"             ;;
       float     ) (($#)) && ERX "$err expected 0 arguments got '($*)'"     ;;
       orientation )
-        ex="vertical|horizontal"
+        ex="vertical|horizontal|toggle"
         [[ $arg =~ ${ex} ]] || ERX "$err expected ($ex)" 
         ;;
     esac

--- a/src/i3fyra/i3fyra
+++ b/src/i3fyra/i3fyra
@@ -15,7 +15,7 @@ main(){
     exit
   }
 
-  for _action in move show hide layout float orientation mono; do
+  for _action in move show hide layout float orientation mono rotate; do
     
     [[ ${arg:=${_o[$_action]}} ]] || continue
     err="i3fyra: argument for '--$_action': '$arg' not valid!"
@@ -25,10 +25,10 @@ main(){
         ex="A|B|C|D|l|r|u|d|left|right|up|down"
         [[ $arg =~ ^(${ex})$ ]] || ERX "$err expected ($ex)"
         ;;
-      
-      show|hide ) [[ $arg =~ ^[ABCD]+$ ]] || ERX "$err expected (A|B|C|D)" ;;
-      layout    ) [[ $arg =~ = || $arg = redo ]] || ERX "$err"             ;;
-      float     ) (($#)) && ERX "$err expected 0 arguments got '($*)'"     ;;
+      rotate    ) [[ $arg =~ ^(family|sibling)$ ]] || ERX "$err expected (family|sibling)" ;;
+      show|hide ) [[ $arg =~ ^[ABCD]+$ ]]          || ERX "$err expected (A|B|C|D)"      ;;
+      layout    ) [[ $arg =~ = || $arg = redo ]]   || ERX "$err"                         ;;
+      float     ) (($#)) && ERX "$err expected 0 arguments got '($*)'"                 ;;
       orientation )
         ex="vertical|horizontal|toggle"
         [[ $arg =~ ${ex} ]] || ERX "$err expected ($ex)" 
@@ -55,12 +55,13 @@ main(){
         else active_move_in_direction "${arg:0:1}"
       fi
     ;;
-    show        ) container_show "$arg" ;;
-    hide        ) container_hide "$arg" ;;
-    layout      ) apply_splits "$arg"   ;;
-    float       ) float_toggle          ;;
-    orientation ) orientation "$arg"    ;;
-    mono        ) monocle_toggle        ;;
+    show        ) container_show "$arg"   ;;
+    hide        ) container_hide "$arg"   ;;
+    layout      ) apply_splits "$arg"     ;;
+    float       ) float_toggle            ;;
+    orientation ) orientation "$arg"      ;;
+    mono        ) monocle_toggle          ;;
+    rotate      ) rotate "$arg"           ;;
 
   esac
 

--- a/src/i3fyra/i3fyra.1
+++ b/src/i3fyra/i3fyra.1
@@ -1,14 +1,10 @@
 .nh
-.TH I3FYRA   2023-07-22 budlabs "User Manuals"
+.TH I3FYRA   2025-12-27 budlabs "User Manuals"
 .SH NAME
-.PP
-i3fyra - An advanced, simple grid-based tiling layout
+i3fyra \- An advanced, simple grid-based tiling layout
 
 .SH SYNOPSIS
-.PP
-.RS
-
-.nf
+.EX
 i3fyra --show|-s CONTAINER
 i3fyra --float|-a
 i3fyra --hide|-z CONTAINER
@@ -16,25 +12,20 @@ i3fyra --layout|-l LAYOUT [--array ARRAY]
 i3fyra --move|-m DEST [--conid|-n CON_ID] [--speed|-p INT]
 i3fyra --orientation ORIENTATION
 i3fyra --clear-virtuals
+i3fyra --mono|-M
+i3fyra --rotate AXIS
 i3fyra [--verbose] [--dryrun] [--force|-f] 
 i3fyra --help|-h
 i3fyra --version|-v 
-
-.fi
-.RE
+.EE
 
 .PP
 The layout consists of four containers:
 
-.PP
-.RS
-
-.nf
+.EX
   A B
   C D
-
-.fi
-.RE
+.EE
 
 .PP
 A container can contain one or more windows. The
@@ -66,15 +57,15 @@ toggled. Not visible containers are placed on the
 scratchpad.
 
 .PP
-The visibility is toggled by either using \fB\fC--show\fR
-or \fB\fC--hide\fR\&. But more often by moving a container
+The visibility is toggled by either using \fB--show\fR
+or \fB--hide\fR\&. But more often by moving a container
 in an \fIimpossible\fP direction,(\fIsee examples
 below\fP).
 
 .PP
 The \fBi3fyra\fP layout is only active on one
 workspace. That workspace can be set with the
-environment variable: \fB\fCi3FYRA_WS\fR, otherwise the
+environment variable: \fBi3FYRA_WS\fR, otherwise the
 workspace active when the layout is created will
 be used.
 
@@ -87,59 +78,43 @@ with \fIdefault i3\fP\&.
 
 
 .SH examples
-.PP
 If containers \fBA\fP,\fBB\fP and \fBC\fP are visible
 but \fBD\fP is hidden or none existent, the visible
 layout would looks like this:
 
-.PP
-.RS
-
-.nf
+.EX
   A B
   C B
-
-.fi
-.RE
+.EE
 
 .PP
-If action: \fB\fC--move up\fR would be executed when
+If action: \fB--move up\fR would be executed when
 container \fBB\fP is active and \fBD\fP is hidden.
 Container \fBD\fP would be shown. If action would
-have been: \fB\fC--move down\fR, \fBD\fP would be shown
+have been: \fB--move down\fR, \fBD\fP would be shown
 but \fBB\fP would be placed below \fBD\fP, this means
 that the containers will also swap names. If
-action would have been \fB\fC--move left\fR the active
+action would have been \fB--move left\fR the active
 window in B would be moved to container \fBA\fP\&. If
-action was \fB\fC--move right\fR, \fBA\fP and \fBC\fP would
+action was \fB--move right\fR, \fBA\fP and \fBC\fP would
 be hidden:
 
-.PP
-.RS
-
-.nf
+.EX
   B B
   B B
-
-.fi
-.RE
+.EE
 
 .PP
-If we now \fB\fC--move left\fR, \fBA\fP and \fBC\fP
+If we now \fB--move left\fR, \fBA\fP and \fBC\fP
 would be shown again but to the right of \fBB\fP,
 the containers would also change names, so \fBB\fP
 becomes \fBA\fP, \fBA\fP becomes \fBB\fP and \fBC\fP
 becomes \fBD\fP:
 
-.PP
-.RS
-
-.nf
+.EX
   A B
   A D
-
-.fi
-.RE
+.EE
 
 .PP
 If this doesn't make sense, check out this
@@ -147,10 +122,7 @@ demonstration on youtube:
 https://youtu.be/kU8gb6WLFk8
 
 .SH OPTIONS
-.PP
-.RS
-
-.nf
+.EX
 --array              ARRAY       | ARRAY should be the output of `i3list`  
 --clear-virtuals                 | clear/reset virtual positions  
 -n, --conid          CON_ID      | window with **CON_ID** will be used instead of active window  
@@ -160,34 +132,31 @@ https://youtu.be/kU8gb6WLFk8
 -h, --help                       | print help and exit  
 -z, --hide           CONTAINER   | Hide target containers if visible.  
 -l, --layout         LAYOUT      | update the size of the layout  
+-M, --mono                       | toggle monocle mode 
 -m, --move           DEST        | move window/create container  
---orientation        ORIENTATION | short description  
+--orientation        ORIENTATION | main split orientation on i3fyra WS (horizontal|vertical|toggle)
+--rotate             AXIS        | switch position with <sibling|family>  
 -s, --show           CONTAINER   | Show target container.  
 -p, --speed          INT         | distance in px a floating windows will be moved  
 --verbose                        | print more stuff to stderr  
 -v, --version                    | louder output  
-
-.fi
-.RE
+.EE
 
 .SS --array              ARRAY
-.PP
-Use \fB\fC--array ARRAY\fR to improve speed when
+Use \fB--array ARRAY\fR to improve speed when
 \fBi3fyra\fP is executed from a script that already
 have the array, f.i. \fBi3run\fP and \fBi3Kornhe\fP\&.
 
 .SS -a, --float
-.PP
 Autolayout. If current window is tiled: floating
 enabled If window is floating, it will be put in a
 visible container. If there is no visible
 containers. The window will be placed in a hidden
 container. If no containers exist, container
-'A'will be created and the window will be put
+\&'A'will be created and the window will be put
 there.
 
 .SS -l, --layout         LAYOUT
-.PP
 AB is point on the X axis, calculated from the
 left side if INT is positive, from the right side
 if it is negative. AC and BD is on Y axis from
@@ -203,66 +172,58 @@ LAYOUT argument can also be the word 'redo', if it
 is, the last layout appended will be restored.
 
 .SS -m, --move           DEST
-.PP
 DEST can either be the name of a container
 (A|B|C|D), or it's position relative to the
-current container with a direction:[\fB\fCl\fR|\fB\fCleft\fR]
-[\fB\fCr\fR|\fB\fCright\fR][\fB\fCu\fR|\fB\fCup\fR][\fB\fCd\fR|\fB\fCdown\fR] If the
+current container with a direction:[\fBl\fR|\fBleft\fR]
+[\fBr\fR|\fBright\fR][\fBu\fR|\fBup\fR][\fBd\fR|\fBdown\fR] If the
 container doesnt exist it is created. If argument
 is a direction and there is no container in that
 direction, Connected container(s) visibility is
 toggled. If current window is floating or not
 inside ABCD, normal movement is performed.
 Distance for moving floating windows with this
-action can be defined with the \fB\fC--speed\fR option.
-Example: \fB\fC$ i3fyra --speed 30 -m r\fR Will move
+action can be defined with the \fB--speed\fR option.
+Example: \fB$ i3fyra --speed 30 -m r\fR Will move
 current window 30 pixels to the right, if it is
 floating.
 
 .SS -s, --show           CONTAINER
-.PP
 If it doesn't exist, it will be created and
 current window will be put in it. If it is
 visible, nothing happens.
 
 .SH ENVIRONMENT
 .SS I3FYRA_WS
-.PP
 Workspace to use for i3fyra. If not set, the firs
 workspace that request to create the layout will
 be used.
 
 .SS I3FYRA_MAIN_CONTAINER
-.PP
 This container will be the chosen when a container
 is requested but not given. When using the command
-autolayout (\fB\fC-a\fR) for example, if the window is
+autolayout (\fB-a\fR) for example, if the window is
 floating it will be sent to the main container, if
 no other containers exist. Defaults to A.
 
 .SS I3FYRA_ORIENTATION
-.PP
-If set to \fB\fCvertical\fR main split will be \fB\fCAC\fR and
-families will be \fB\fCAB\fR and \fB\fCCD\fR\&. Otherwise main
-split will be \fB\fCAB\fR and families will be \fB\fCAC\fR and
-\fB\fCBD\fR\&.
+If set to \fBvertical\fR main split will be \fBAC\fR and
+families will be \fBAB\fR and \fBCD\fR\&. Otherwise main
+split will be \fBAB\fR and families will be \fBAC\fR and
+\fBBD\fR\&.
 
 .SS I3_KING_PID_FILE
-.PP
 When i3king is running this file contains the pid
 of the i3king process. It is used by \fBi3fyra\fP to
 know if i3king is running, if it is, it will try
-to match windows against the rules when \fB\fC--float\fR
+to match windows against the rules when \fB--float\fR
 option toggles the floating state to tiled.
 
 .SH CONTACT
-.PP
 Send bugs and feature requests to:
 .br
 https://github.com/budlabs/i3ass/issues
 
 .SH COPYRIGHT
-.PP
-Copyright (c) 2017-2023, budRich of budlabs
+Copyright (c) 2017-2025, budRich of budlabs
 .br
 SPDX-License-Identifier: MIT

--- a/src/i3fyra/options
+++ b/src/i3fyra/options
@@ -5,7 +5,7 @@
 --move|-m DEST [--conid|-n CON_ID] [--speed|-p INT]
 --orientation ORIENTATION
 --clear-virtuals
---mono
+--mono|-M
 --rotate AXIS
 [--verbose] [--dryrun] [--force|-f] 
 --help|-h

--- a/src/i3fyra/options
+++ b/src/i3fyra/options
@@ -5,6 +5,7 @@
 --move|-m DEST [--conid|-n CON_ID] [--speed|-p INT]
 --orientation ORIENTATION
 --clear-virtuals
+--mono
 [--verbose] [--dryrun] [--force|-f] 
 --help|-h
 --version|-v 

--- a/src/i3fyra/options
+++ b/src/i3fyra/options
@@ -6,6 +6,7 @@
 --orientation ORIENTATION
 --clear-virtuals
 --mono
+--rotate AXIS
 [--verbose] [--dryrun] [--force|-f] 
 --help|-h
 --version|-v 

--- a/src/i3get/i3get.1
+++ b/src/i3get/i3get.1
@@ -1,18 +1,14 @@
+'\" t
 .nh
-.TH I3GET   2022-07-19 budlabs "User Manuals"
+.TH I3GET   2024-04-21 budlabs "User Manuals"
 .SH NAME
-.PP
-i3get - prints info about a specific window to stdout
+i3get \- prints info about a specific window to stdout
 
 .SH SYNOPSIS
-.PP
-\fB\fCi3get [OPTIONS]\fR
+\fBi3get [OPTIONS]\fR
 
 .SH OPTIONS
-.PP
-.RS
-
-.nf
+.EX
 -c, --class        CLASS         | target windows with CLASS  
 -n, --conid        CON_ID        | target windows with CON_ID  
 -h, --help                       | print help and exit  
@@ -31,12 +27,9 @@ i3get - prints info about a specific window to stdout
 --verbose                        | print messages to stderr  
 -v, --version                    | print version info and exit  
 --winid            WIN_ID        | target windows with WIN_ID  
-
-.fi
-.RE
+.EE
 
 .SS -r, --print        OUTPUT
-.PP
 \fIOUTPUT\fP can be one or more of the following
 characters:
 
@@ -44,83 +37,69 @@ characters:
 allbox;
 l l l 
 l l l .
-\fB\fCcharacter\fR	\fB\fCprint\fR	\fB\fCreturn\fR
-\fB\fCt\fR	title	string
-\fB\fCc\fR	class	string
-\fB\fCi\fR	instance	string
-\fB\fCd\fR	Window ID	INT
-\fB\fCn\fR	Con_Id (default)	INT
-\fB\fCm\fR	mark	JSON list
-\fB\fCw\fR	workspace number	INT
-\fB\fCW\fR	workspace name	STRING
-\fB\fCa\fR	is active	true or false
-\fB\fCf\fR	floating state	string
-\fB\fCo\fR	title format	string
-\fB\fCe\fR	fullscreen	1 or 0
-\fB\fCs\fR	sticky	true or false
-\fB\fCu\fR	urgent	true or false
-\fB\fCy\fR	window_type	string
-\fB\fCr\fR	window_role	string
+\fBcharacter\fP	\fBprint\fP	\fBreturn\fP
+\fBt\fR	title	string
+\fBc\fR	class	string
+\fBi\fR	instance	string
+\fBd\fR	Window ID	INT
+\fBn\fR	Con_Id (default)	INT
+\fBm\fR	mark	JSON list
+\fBw\fR	workspace number	INT
+\fBW\fR	workspace name	STRING
+\fBa\fR	is active	true or false
+\fBf\fR	floating state	string
+\fBo\fR	title format	string
+\fBe\fR	fullscreen	1 or 0
+\fBs\fR	sticky	true or false
+\fBu\fR	urgent	true or false
+\fBy\fR	window_type	string
+\fBr\fR	window_role	string
 .TE
 
 .PP
 Each character in OUTPUT will be tested and the
 return value will be printed on a new line. If no
-value is found, \fB\fC--i3get could not find:
+value is found, \fB--i3get could not find:
 CHARACTER\fR will get printed.
 
 .PP
 In the example below, the target window did not have a mark:
 
-.PP
-.RS
-
-.nf
+.EX
 $ i3get -r tfcmw
 /dev/pts/9
 user_off
 URxvt
 --i3get could not find: m
 1
-
-.fi
-.RE
+.EE
 
 .SH USAGE
-.PP
-Search for \fB\fCCRITERIA\fR in the output of \fB\fCi3-msg -t get_tree\fR,
+Search for \fBCRITERIA\fR in the output of \fBi3-msg -t get_tree\fR,
 return desired information.
 If no arguments are passed,
-\fB\fCcon_id\fR of active window is returned.
+\fBcon_id\fR of active window is returned.
 If there is more then one criterion,
 all of them must be true to get results.
 
 
 .SH EXAMPLES
-.PP
 search for window with instance name sublime_text.
 Request workspace, title and floating state.
 
-.PP
-.RS
-
-.nf
+.EX
 $ i3get --instance sublime_text --print wtf 
 1
 ~/src/bash/i3ass/i3get (i3ass) - Sublime Text
 user_off
-
-.fi
-.RE
+.EE
 
 .SH CONTACT
-.PP
 Send bugs and feature requests to:
 .br
 https://github.com/budlabs/i3ass/issues
 
 .SH COPYRIGHT
-.PP
-Copyright (c) 2017-2023, budRich of budlabs
+Copyright (c) 2017-2025, budRich of budlabs
 .br
 SPDX-License-Identifier: MIT

--- a/src/i3gw/i3gw.1
+++ b/src/i3gw/i3gw.1
@@ -1,70 +1,54 @@
 .nh
 .TH I3GW   2022-05-21 budlabs "User Manuals"
 .SH NAME
-.PP
-i3gw - a ghost window wrapper for i3wm
+i3gw \- a ghost window wrapper for i3wm
 
 .SH SYNOPSIS
-.PP
-\fB\fCi3gw MARK\fR
+\fBi3gw MARK\fR
 
 .SH OPTIONS
-.PP
-.RS
-
-.nf
+.EX
 -h, --help     | print help and exit  
 --verbose      | short description  
 -v, --version  | print messages to stderr  
-
-.fi
-.RE
+.EE
 
 .SH USAGE
-.PP
-\fB\fCi3-msg\fR has an undocumented function: \fIopen\fP,
+\fBi3-msg\fR has an undocumented function: \fIopen\fP,
 it creates empty containers,
 or as I call them: ghosts.
 Since these empty containers doesn't contain any windows
 there is no instance/class/title to identify them,
 making it difficult to manage them.
-They do however have a \fB\fCcon_id\fR
+They do however have a \fBcon_id\fR
 and I found that the easiest way to keep track of ghosts, is to mark them.
 That is what this script does,
 it creates a ghost,
-get its \fB\fCcon_id\fR and marks it.
+get its \fBcon_id\fR and marks it.
 
 .SH EXAMPLES
-.PP
-\fB\fC$ i3gw casper\fR
+\fB$ i3gw casper\fR
 
 .PP
 this will create a ghost marked casper,
 you can perform any action you can perform on a regular container.
 
-.PP
-.RS
-
-.nf
+.EX
 $ i3-msg [con_mark=casper] move to workspace 2
 $ i3-msg [con_mark=casper] split v
 $ i3-msg [con_mark=casper] layout tabbed
 $ i3-msg [con_mark=casper] kill
-
-.fi
-.RE
+.EE
 
 .PP
-the last command (\fB\fCkill\fR), destroys the container.
+the last command (\fBkill\fR), destroys the container.
 
 .SH CONTACT
-.PP
 Send bugs and feature requests to:
 .br
 https://github.com/budlabs/i3ass/issues
 
 .SH COPYRIGHT
-.PP
-Copyright (c) 2017-2023, budRich of budlabs
+Copyright (c) 2017-2025, budRich of budlabs
 .br
 SPDX-License-Identifier: MIT

--- a/src/i3king/config.mak
+++ b/src/i3king/config.mak
@@ -1,7 +1,7 @@
 NAME         := i3king
-VERSION      := 0.4.3
+VERSION      := 0.4.4
 CREATED      := 2021-06-01
-UPDATED      := 2023-08-04
+UPDATED      := 2025-03-30
 AUTHOR       := budRich
 CONTACT      := https://github.com/budlabs/i3ass
 USAGE        := i3king [OPTIONS]

--- a/src/i3king/func/parse_rules.sh
+++ b/src/i3king/func/parse_rules.sh
@@ -74,17 +74,16 @@ parse_rules() {
 
       for crit in "${ignore_combined[@]}"; do
 
-        [[ $crit =~ = ]] || {
+        [[ $crit =~ = || $rule_type =~ DEFAULT|GLOBAL ]] || {
           ERR "'$line'" $'\n' \
-              "Expected criteria, got ('$crit')" \
-              "A missplaced command? maybe."
+              "Expected criteria, got ('$crit') A missplaced command?"
 
           continue
         }
 
         # if we don't have  a criteria it is
-        # a line with a single GLOBAL/NORMAL
-        # we set the rule to nonsense (-)
+        # a line with a single GLOBAL/DEFAULT
+        # we set the (blacklist) rule to nonsense (-)
         # to make sure it never matches
         if [[ $crit ]]; then
           wc="${_fs}[^${_fs}]*$_fs" # wildcard :.*:

--- a/src/i3king/i3king.1
+++ b/src/i3king/i3king.1
@@ -1,18 +1,13 @@
 .nh
-.TH I3KING   2023-08-04 budlabs "User Manuals"
+.TH I3KING   2025-03-30 budlabs "User Manuals"
 .SH NAME
-.PP
-i3king - window ruler
+i3king \- window ruler
 
 .SH SYNOPSIS
-.PP
-\fB\fCi3king [OPTIONS]\fR
+\fBi3king [OPTIONS]\fR
 
 .SH OPTIONS
-.PP
-.RS
-
-.nf
+.EX
 -a, --apply                | Match all existing windows against the rules and exit.
 -c, --config         FILE  | use FILE as config  
 -n, --conid          CONID | window with CONID, match against rules and exit exit.
@@ -27,36 +22,30 @@ i3king - window ruler
 --verbose                  | More verbose output to **STDERR**.  
 -v, --version              | print version info and exit  
 -d, --winid          WINID | window with WINID, match against rules and exit exit.  
-
-.fi
-.RE
+.EE
 
 .SS -c, --config         FILE
-.PP
 Override the value of the Environment variable
 \fBI3_KING_RULE_FILE\fP . Or the default value:
 .br
-\fB\fC~/.config/i3king/rules\fR
+\fB~/.config/i3king/rules\fR
 
 .SS --no-apply
-.PP
 If this option is set it will not automatically
 apply rules to all windows when the IPC socket is
-broken (happens on a crash or on \fB\fCrestart\fR).
-This option has no effect if \fB\fC--no-restart\fR is used.
+broken (happens on a crash or on \fBrestart\fR).
+This option has no effect if \fB--no-restart\fR is used.
 
 .SS --no-restart
-.PP
 When the IPC socket is broken, i3king will automatically
 restart if this option is not set.
 
 .SH USAGE
-.PP
 i3king will match all \fBnew\fP windows against the
 rules defined in \fBI3_KING_RULE_FILE\fP
-(\fI\fB\fC~/.config/i3king/rules\fR\fP). If a rule matches
+(\fI\fB~/.config/i3king/rules\fR\fP). If a rule matches
 the created window, the command associated with
-the rule will get passed to \fB\fCi3-msg\fR\&.
+the rule will get passed to \fBi3-msg\fR\&.
 
 .PP
 The criterias a window can get matched against are
@@ -83,13 +72,11 @@ only get triggered if the window didn't match any
 trigger when a window is closed.
 
 .PP
-Just like in the i3 config the \fB\fCset\fR directive is
+Just like in the i3 config the \fBset\fR directive is
 available, so you can make variables.
 
 .PP
 Some built in magic variables are avaible in the config:
-
-.RS
 .IP \(bu 2
 $INSTANCE
 .IP \(bu 2
@@ -101,31 +88,26 @@ $WINID
 .IP \(bu 2
 $TITLE
 
-.RE
-
 .PP
 \fBTITLE\fP is a rule type that works slightly different
 than the others. If triggered it will always execute
-the command \fB\fCtitle_format NEW_TITLE\fR\&. And triggers
+the command \fBtitle_format NEW_TITLE\fR\&. And triggers
 on new windows and when a window title changes.
 
 .PP
-Instead of a command you specify: \fB\fC[option]/REGEX/ template\fR
-Use \fB\fC$1,$2,$3...\fR in the template to expand them to
+Instead of a command you specify: \fB[option]/REGEX/ template\fR
+Use \fB$1,$2,$3...\fR in the template to expand them to
 the corresponding capture group from the regex.
 
 .PP
-\fB\fC[option]\fR is optional and can be either:
+\fB[option]\fR is optional and can be either:
 .br
-- \fB\fC~0\fR remove expanded $HOME/ from NEW_TITLE
-  \fIif this results in empty NEW_TITLE, a single \fB\fC~\fR will be used\fP
-- \fB\fC~1\fR replace expanded $HOME with \fB\fC~\fR
+- \fB~0\fR remove expanded $HOME/ from NEW_TITLE
+  \fIif this results in empty NEW_TITLE, a single \fB~\fR will be used\fP
+- \fB~1\fR replace expanded $HOME with \fB~\fR
 
 .SH EXAMPLE
-.PP
-.RS
-
-.nf
+.EX
 # assuming the window class is "Thunar" and the window
 # title is something like "/home/anon/.config/i3 - Thunar"
 
@@ -147,22 +129,15 @@ TITLE class=Thunar
 # the above will result in NEW_TITLE: 
 # ~/.config/i3
 
-
-.fi
-.RE
+.EE
 
 .SH EXAMPLE
-.PP
-.RS
-
-.nf
+.EX
 GLOBAL \\
   class=URxvt instance=htop, \\
   instance=firefox
     title_format $INSTANCE
-
-.fi
-.RE
+.EE
 
 .PP
 The above rule will set the title_format to the instance
@@ -175,30 +150,25 @@ a example rule file will get created. See that
 file for details about the syntax.
 
 .PP
-If you used to have \fB\fCfor_window\fR rules that triggered
-\fB\fCi3fyra --move\fR commands. It is recommended to use
+If you used to have \fBfor_window\fR rules that triggered
+\fBi3fyra --move\fR commands. It is recommended to use
 the built in varialbe \fB$CONID\fP when executing i3fyra:
 
 .SH EXAMPLE
-.PP
-.RS
-
-.nf
+.EX
 # old i3 version:
 for_window [instance=qutebrowser] exec --no-startup-id i3fyra --move C
 
 # with i3 king:
 instance=qutebrowser
   exec --no-startup-id i3fyra --conid $CONID --move C
-
-.fi
-.RE
+.EE
 
 .PP
-(\fIthe \fB\fC--conid\fR option in i3fyra is brand new\fP)
+(\fIthe \fB--conid\fR option in i3fyra is brand new\fP)
 
 .PP
-If the \fB\fCrestart\fR command is issued from i3, all
+If the \fBrestart\fR command is issued from i3, all
 windows lose gets new container IDs, marks are
 lost and other more or less strange things might
 happen to the layout. Another thing is that all
@@ -207,39 +177,33 @@ any ipc subscriber would have to be restarted.
 \fBi3king\fP will, when the socket is broken, match
 all known windows against the rules again, and
 automatically restart itself. If you for some
-reason don't want this behaviour, try \fB\fC--no-
-restart\fR and/or \fB\fC--no-apply\fR options.
+reason don't want this behaviour, try \fB--no-
+restart\fR and/or \fB--no-apply\fR options.
 
 .SH protip
-.PP
 Sending USR1 to the i3king process will restart
-i3king. Hint: \fB\fCkill -USR1 $(< "$XDG_RUNTIME_DIR/i3ass/i3king.pid")\fR
+i3king. Hint: \fBkill -USR1 $(< "$XDG_RUNTIME_DIR/i3ass/i3king.pid")\fR
 
 .SH ENVIRONMENT
 .SS BASHBUD_DIR
-.PP
 bashbud config dir location.
 
 .SS I3_KING_RULE_FILE
-.PP
 Path to file containing rules to be parsed.
 
 .SS I3_KING_PID_FILE
-.PP
 When i3king is running this file contains the pid
 of the i3king process. It is used by \fBi3fyra\fP to
 know if i3king is running, if it is, it will try
-to match windows against the rules when \fB\fC--float\fR
+to match windows against the rules when \fB--float\fR
 option toggles the floating state to tiled.
 
 .SH CONTACT
-.PP
 Send bugs and feature requests to:
 .br
 https://github.com/budlabs/i3ass/issues
 
 .SH COPYRIGHT
-.PP
-Copyright (c) 2021-2023, budRich of budlabs
+Copyright (c) 2021-2025, budRich of budlabs
 .br
 SPDX-License-Identifier: MIT

--- a/src/i3list/i3list.1
+++ b/src/i3list/i3list.1
@@ -1,14 +1,10 @@
 .nh
-.TH I3LIST   2023-07-12 budlabs "User Manuals"
+.TH I3LIST   2024-04-21 budlabs "User Manuals"
 .SH NAME
-.PP
-i3list - list information about the current i3 session
+i3list \- list information about the current i3 session
 
 .SH SYNOPSIS
-.PP
-.RS
-
-.nf
+.EX
 i3list     [--json JSON]
 i3list     --instance|-i TARGET [--json JSON] [--verbose]
 i3list     --class|-c    TARGET [--json JSON] [--verbose]
@@ -18,15 +14,10 @@ i3list     --mark|-m     TARGET [--json JSON] [--verbose]
 i3list     --title|-t    TARGET [--json JSON] [--verbose]
 i3list     --help|-h
 i3list     --version|-v
-
-.fi
-.RE
+.EE
 
 .SH OPTIONS
-.PP
-.RS
-
-.nf
+.EX
 -c, --class    TARGET | Search for windows with a class matching *TARGET*  
 -n, --conid    TARGET | Search for windows with a CON_ID matching TARGET  
 -h, --help            | print help and exit  
@@ -37,15 +28,12 @@ i3list     --version|-v
 --verbose             | Short description  
 -v, --version         | Print version info and exit  
 -d, --winid    TARGET | Search for windows with a **WINDOW_ID** matching *TARGET*  
-
-.fi
-.RE
+.EE
 
 .SH USAGE
-.PP
-\fB\fCi3list\fR prints a list in a \fIarray\fP formatted list.
+\fBi3list\fR prints a list in a \fIarray\fP formatted list.
 If a search criteria is given
-(\fB\fC-c\fR|\fB\fC-i\fR|\fB\fC-n\fR|\fB\fC-d\fR|\fB\fC-m\fR)
+(\fB-c\fR|\fB-i\fR|\fB-n\fR|\fB-d\fR|\fB-m\fR)
 information about the first window matching the criteria is displayed.
 Information about the active window is always displayed.
 If no search criteria is given,
@@ -57,10 +45,7 @@ the output can be used as an array in bash scripts,
 but the array needs to be declared first.
 
 .SH EXAMPLE
-.PP
-.RS
-
-.nf
+.EX
 $ i3list
 i3list[AWF]=0                  # Active Window floating
 i3list[ATW]=270                # Active Window tab width
@@ -142,18 +127,14 @@ $ declare -A i3list # declares associative array
 $ eval "$(i3list)"
 $ echo ${i3list[WAW]}
 1080
-
-.fi
-.RE
+.EE
 
 .SH CONTACT
-.PP
 Send bugs and feature requests to:
 .br
 https://github.com/budlabs/i3ass/issues
 
 .SH COPYRIGHT
-.PP
-Copyright (c) 2017-2023, budRich of budlabs
+Copyright (c) 2017-2025, budRich of budlabs
 .br
 SPDX-License-Identifier: MIT

--- a/src/i3run/i3run.1
+++ b/src/i3run/i3run.1
@@ -1,14 +1,10 @@
 .nh
-.TH I3RUN   2022-05-22 budlabs "User Manuals"
+.TH I3RUN   2024-04-21 budlabs "User Manuals"
 .SH NAME
-.PP
-i3run - Run, Raise or hide windows in i3wm
+i3run \- Run, Raise or hide windows in i3wm
 
 .SH SYNOPSIS
-.PP
-.RS
-
-.nf
+.EX
 i3run --instance|-i INSTANCE  [--hide] [--summon|-s] [--nohide|-g] [--verbose] [--silent]
 i3run --class|-c    CLASS     [--hide] [--rename|-x OLD_NAME] 
 i3run --title|-t    TITLE     [--hide] [--rename-instance OLD_NAME] [--rename-class OLD_NAME] [--rename-title OLD_NAME]
@@ -16,15 +12,10 @@ i3run --conid|-n    CON_ID    [--hide] [--force|-f] [--FORCE|-F]
 i3run --winid|-d    WIN_ID    [--hide] [--command|-e COMMAND] [--mouse|-m]
 i3run --help|-h
 i3run --version|-v
-
-.fi
-.RE
+.EE
 
 .SH OPTIONS
-.PP
-.RS
-
-.nf
+.EX
 -F, --FORCE                    | Execute COMMAND (`--command`), even if the window already exist. 
 -c, --class           CLASS    | Search for windows with the given CLASS
 -e, --command         COMMAND  | execute COMMAND if window is not found  
@@ -45,38 +36,29 @@ i3run --version|-v
 --verbose                      | More stuff is printed to stderr  
 -v, --version                  | print version info and exit  
 -d, --winid           WIN_ID   | Search for windows with WIN_ID  
-
-.fi
-.RE
+.EE
 
 .SS -e, --command         COMMAND
-.PP
 \fBExample\fP
 
-.PP
-.RS
-
-.nf
+.EX
 # with --command:
 i3run --instance sublime_text --command 'subl && notify-send "sublime is started"'
 
 # with -- (recomended)
 i3run --instance sublime_text -- subl "&&" notify-send "sublime is started"
-
-.fi
-.RE
+.EE
 
 .PP
 Notice that you will need to \fIescape\fP some shell
-builtins that effect the commandline (\fB\fC&&\fR, \fB\fC;\fR,
-\fB\fC&\fR, \fB\fC|\fR, \fB\fC||\fR ...) in the second example.
+builtins that effect the commandline (\fB&&\fR, \fB;\fR,
+\fB&\fR, \fB|\fR, \fB||\fR ...) in the second example.
 
 .SS -x, --rename          OLD_NAME
-.PP
-If the search criteria is \fB\fC--instance\fR, the window
+If the search criteria is \fB--instance\fR, the window
 with instance: \fIOLDNAME\fP will get a new instance
 name matching the criteria when it is created
-(\fIneeds \fB\fCxdotool\fR\fP).
+(\fIneeds \fBxdotool\fR\fP).
 
 .PP
 \fBNB\fP
@@ -84,12 +66,9 @@ name matching the criteria when it is created
 This option will not work reliably when using multiple
 search criteria. When you want to do that instead use:
 .br
-\fB\fC--rename-instance , --rename-class , --rename-title\fR .
+\fB--rename-instance , --rename-class , --rename-title\fR .
 
-.PP
-.RS
-
-.nf
+.EX
 i3run --instance budswin --rename sublime_main -- subl
 
 # when the command above is executed:
@@ -107,16 +86,13 @@ i3run --title bud --instance budswin --rename sublime_main -- subl
 
 # do this instead:  
 i3run --title bud --instance budswin --rename-instance sublime_main -- subl
-
-.fi
-.RE
+.EE
 
 .SH USAGE
-.PP
 i3run will try to find a window matching a criteria.
 Criteria is specified with one or more command line options:
 .br
-\fB\fC--class , --instance , --title , --conid , --winid\fR
+\fB--class , --instance , --title , --conid , --winid\fR
 .br
 All criteria specified must match, if multiple windows
 match all criteria one will be chosen at random.
@@ -124,10 +100,7 @@ match all criteria one will be chosen at random.
 .PP
 Depending on the state of target window different actions will apply:
 
-.PP
-.RS
-
-.nf
+.EX
 Active and not handled by i3fyra     | send to scratchpad
 Active and handled by i3fyra         | send container to scratchpad
 Handled by i3fyra and hidden         | **show** container
@@ -135,9 +108,7 @@ Not handled by i3fyra and hidden     | **show** window
 Not on current workspace             | goto workspace and focus window
 Not active, not hidden, on workspace | focus window
 Not found                            | execute COMMAND
-
-.fi
-.RE
+.EE
 
 .PP
 Hidden in this context,  means that window is on
@@ -145,41 +116,38 @@ the scratchpad. Show in this context means,  move
 window to current workspace.
 
 .PP
-With \fB\fC--nohide\fR set windows/containers will not be
+With \fB--nohide\fR set windows/containers will not be
 sent to the scratchpad by \fBi3run\fP\&.
 
 .PP
-With \fB\fC--summon\fR windows not on current workspace
+With \fB--summon\fR windows not on current workspace
 will be sent to current workspace instead of switching
 workspace.
 
 .PP
-COMMAND is everything after -- , or the argument to \fB\fC--command\fR\&.
+COMMAND is everything after -- , or the argument to \fB--command\fR\&.
 
 .PP
 If COMMAND doesn't result in a window that matches the criteria
 \fBi3run\fP will \fIget stuck\fP waiting for such a window, and it can
 lead to undesired behavior.
 .br
-Don't do this: \fB\fCi3run --class Google-chrome -- firefox\fR
+Don't do this: \fBi3run --class Google-chrome -- firefox\fR
 
 .SH ENVIRONMENT
 .SS I3RUN_BOTTOM_GAP, I3RUN_RIGHT_GAP, I3RUN_LEFT_GAP, I3RUN_TOP_GAP
-.PP
 Distance from the screen edge to
 show floating windows. This only has effect When
-\fB\fC--mouse\fR option is used and the window needs to
+\fB--mouse\fR option is used and the window needs to
 be autoadjusted not to be rendered \fIoutisde\fP the
 workspace.
 
 .SH CONTACT
-.PP
 Send bugs and feature requests to:
 .br
 https://github.com/budlabs/i3ass/issues
 
 .SH COPYRIGHT
-.PP
-Copyright (c) 2017-2023, budRich of budlabs
+Copyright (c) 2017-2025, budRich of budlabs
 .br
 SPDX-License-Identifier: MIT

--- a/src/i3var/i3var.1
+++ b/src/i3var/i3var.1
@@ -1,41 +1,29 @@
 .nh
 .TH I3VAR   2022-05-21 budlabs "User Manuals"
 .SH NAME
-.PP
-i3var - get or set a i3 variable
+i3var \- get or set a i3 variable
 
 .SH SYNOPSIS
-.PP
-.RS
-
-.nf
+.EX
 i3var     set VARNAME [VALUE] [--json JSON]
 i3var     get VARNAME [--json JSON]
 i3var     --help|-h --version|-v --verbose
-
-.fi
-.RE
+.EE
 
 .SH OPTIONS
-.PP
-.RS
-
-.nf
+.EX
 -h, --help         | print help and exit  
 --json        JSON | Use JSON instead of the output of `i3-msg -t get_tree`  
 --verbose          | print messages to stderr  
 -v, --version      | print version info and exit  
-
-.fi
-.RE
+.EE
 
 .SH USAGE
-.PP
-\fB\fCi3var\fR is used to get or set a "variable" that is bound to the current i3wm session.
+\fBi3var\fR is used to get or set a "variable" that is bound to the current i3wm session.
 The variable is actually the mark on the \fBroot container\fP\&.
 
 .PP
-\fB\fCset\fR  [VALUE]
+\fBset\fR  [VALUE]
 .br
 If \fIVARNAME\fP doesn't exist,
 a new window and mark will be created.
@@ -45,19 +33,17 @@ If \fIVALUE\fP is not defined,
 \fIVARNAME\fP will get unset (the mark is removed).
 
 .PP
-\fB\fCget\fR
+\fBget\fR
 .br
 if \fIVARNAME\fP exists,
 its value will be printed to \fBSTDOUT\fP\&.
 
 .SH CONTACT
-.PP
 Send bugs and feature requests to:
 .br
 https://github.com/budlabs/i3ass/issues
 
 .SH COPYRIGHT
-.PP
-Copyright (c) 2017-2023, budRich of budlabs
+Copyright (c) 2017-2025, budRich of budlabs
 .br
 SPDX-License-Identifier: MIT

--- a/src/i3viswiz/i3viswiz.1
+++ b/src/i3viswiz/i3viswiz.1
@@ -1,14 +1,10 @@
 .nh
-.TH I3VISWIZ   2023-07-22 budlabs "User Manuals"
+.TH I3VISWIZ   2024-04-21 budlabs "User Manuals"
 .SH NAME
-.PP
-i3viswiz - professional window focus for i3wm
+i3viswiz \- professional window focus for i3wm
 
 .SH SYNOPSIS
-.PP
-.RS
-
-.nf
+.EX
 i3viswiz     [--gap|-g GAPSIZE] DIRECTION 
 i3viswiz     --title|-t TITLE       [--gap|-g GAPSIZE] [DIRECTION|TARGET] [--focus|-f] 
 i3viswiz     --instance|-i INSTANCE   [--gap|-g GAPSIZE] [DIRECTION|TARGET] [--focus|-f]
@@ -22,15 +18,10 @@ i3viswiz     --scratchpad
 i3viswiz     [--json JSON] [--debug VARLIST] [--debug-format FORMAT] [--verbose]
 i3viswiz     --help|-h
 i3viswiz     --version|-v
-
-.fi
-.RE
+.EE
 
 .SH OPTIONS
-.PP
-.RS
-
-.nf
+.EX
 -c, --class        CLASS     | find window by **class**
 --debug            VARLIST   | detailed output   
 --debug-format     FORMAT    | how to format debug output  
@@ -48,20 +39,14 @@ i3viswiz     --version|-v
 --verbose                    | louder output   
 -v, --version                | print version info and exit  
 -d, --winid        WINID     | window is visible with WINID  
-
-.fi
-.RE
+.EE
 
 .SS --debug            VARLIST
-.PP
 VARLIST is used to determine what to output. By
-default the value of VARLIST is: \fB\fCLIST\fR .
+default the value of VARLIST is: \fBLIST\fR .
 Available units are:
 
-.PP
-.RS
-
-.nf
+.EX
 wall         | none|(up|left|down|right-)(workspace|area)
 trgcon       | container id of the window to be focused
 trgpar       | name of i3fyra container target container is located in
@@ -84,9 +69,7 @@ firstingroup | container ID of the first child in active windows parent containe
 lastingroup  | container ID of the last child in active windows parent container
 LIST         | prints a table with all visible windows
 ALL          | all the above combined
-
-.fi
-.RE
+.EE
 
 .PP
 Multiple units can be used if comma separated.
@@ -100,102 +83,76 @@ search criterion.
 .PP
 Example:
 
-.PP
-.RS
-
-.nf
+.EX
 $ i3viswiz --instance LIST up --debug gap,wall,grouppos
 gap=5 wall=up-area grouppos=1 
-
-.fi
-.RE
+.EE
 
 .SS --debug-format     FORMAT
-.PP
-The default value of FORMAT is "%k=%v ".  \fB\fC%k\fR is
-translated to the key/unit name, and \fB\fC%v\fR to the
+The default value of FORMAT is "%k=%v ".  \fB%k\fR is
+translated to the key/unit name, and \fB%v\fR to the
 value.
 
 .PP
 Example:
 
-.PP
-.RS
-
-.nf
+.EX
 $ i3viswiz --instance LIST u --debug gap,wall,grouppos --debug-format "%v\\n"
 5
 up-area
 1 
-
-.fi
-.RE
+.EE
 
 .SS -f, --focus
-.PP
 if this is not set, the CON_ID of target window will
 get printed to STDOUT.
 
 .SS -p, --parent       CONTAINER
-.PP
 CONTAINER is one of the i3fyra containers: A|B|C|D
 
 .SS --scratchpad
-.PP
 This is useful if you have a f.i. a tabbed container
 on the scratchpad, and you want to get the id of the
 window that have focus in that container.
 
 .SH USAGE
-.PP
-\fB\fCi3viswiz\fR either prints a list of the currently
-visible tiled windows to \fB\fCstdout\fR or shifts the
+\fBi3viswiz\fR either prints a list of the currently
+visible tiled windows to \fBstdout\fR or shifts the
 focus depending on the arguments.
 
 .PP
 If a \fIDIRECTION\fP (left|right|up|down) is passed,
-\fB\fCi3wizvis\fR will shift the focus to the window
+\fBi3wizvis\fR will shift the focus to the window
 closest in the given \fIDIRECTION\fP, or warp focus
 if there are no windows in the given direction.
 
 
 .SH examples
-.PP
 replace the normal i3 focus keybindings with viswiz like this:
 
-.PP
-.RS
-
-.nf
+.EX
 Normal binding:
 bindsym Mod4+Shift+Left   focus left
 
 Wizzy binding:
 bindsym Mod4+Left   exec --no-startup-id i3viswiz left
-
-.fi
-.RE
+.EE
 
 .PP
 example output:
 
-.PP
-.RS
-
-.nf
+.EX
 $ i3viswiz --instance LIST
 
 * 94475856575600 ws: 1 x: 0     y: 0     w: 1558  h: 410   | termsmall
 - 94475856763248 ws: 1 x: 1558  y: 0     w: 362   h: 272   | gl
 - 94475856286352 ws: 1 x: 0     y: 410   w: 1558  h: 643   | sublime_main
 - 94475856449344 ws: 1 x: 1558  y: 272   w: 362   h: 781   | thunar-lna
-
-.fi
-.RE
+.EE
 
 .PP
-If \fB\fC--class\fR , \fB\fC--instance\fR, \fB\fC--title\fR,
-\fB\fC--titleformat\fR, \fB\fC--winid\fR or \fB\fC--parent\fR is used
+If \fB--class\fR , \fB--instance\fR, \fB--title\fR,
+\fB--titleformat\fR, \fB--winid\fR or \fB--parent\fR is used
 together with the argument \fBLIST\fP\&.
 i3viswiz will print this output, with the type in
 the last column of the table (class in the
@@ -209,16 +166,16 @@ a visible window matching the criteria will be printed.
 Assuming the same scenario as the example above,
 the following command:
 .br
-\fB\fC$ i3viswiz --instance termsmall\fR
+\fB$ i3viswiz --instance termsmall\fR
 .br
-will output the container_id (\fB\fC94475856575600\fR).
+will output the container_id (\fB94475856575600\fR).
 .br
 If no window is matching output will be blank.
 
 .PP
 Multiple criteria is allowed:
 .br
-\fB\fC$ i3viswiz --instance termsmall --class URxvt\fR
+\fB$ i3viswiz --instance termsmall --class URxvt\fR
 
 .PP
 \fBfocus wrapping\fP
@@ -238,21 +195,19 @@ before the first i3viswiz invokation.
 To force this behavior otherwise, issue the following
 command:
 .br
-\fB\fCi3var set focus_wrap workspace\fR
+\fBi3var set focus_wrap workspace\fR
 
 .PP
 Or to disable it:
 .br
-\fB\fCi3var set focus_wrap normal\fR
+\fBi3var set focus_wrap normal\fR
 
 .SH CONTACT
-.PP
 Send bugs and feature requests to:
 .br
 https://github.com/budlabs/i3ass/issues
 
 .SH COPYRIGHT
-.PP
-Copyright (c) 2018-2023, budRich of budlabs
+Copyright (c) 2018-2025, budRich of budlabs
 .br
 SPDX-License-Identifier: MIT

--- a/src/i3zen/i3zen.1
+++ b/src/i3zen/i3zen.1
@@ -1,18 +1,13 @@
 .nh
-.TH I3ZEN   2023-07-29 budlabs "User Manuals"
+.TH I3ZEN   2024-04-21 budlabs "User Manuals"
 .SH NAME
-.PP
-i3zen - zentered container, full focus
+i3zen \- zentered container, full focus
 
 .SH SYNOPSIS
-.PP
-\fB\fCi3zen [OPTIONS]\fR
+\fBi3zen [OPTIONS]\fR
 
 .SH OPTIONS
-.PP
-.RS
-
-.nf
+.EX
 --dryrun                  | don't execute any commands  
 --height        INT       | height of zen container in percentage  
 -h, --help                | print help and exit  
@@ -23,24 +18,19 @@ i3zen - zentered container, full focus
 -w, --workspace WORKSPACE | workspace name to use  
 -x, --xpos      INT       | position of container on the X axis
 -y, --ypos      INT       | position of container on the X axis
-
-.fi
-.RE
+.EE
 
 .SS -m, --mark      MARK
-.PP
 If not set the \fIzen container\fP will be marked \fBcenterzen\fP\&.
 If set it will instead be marked MARK when it is created.
 This option can be used to create multiple zen containers.
 
 .SS -w, --workspace WORKSPACE
-.PP
 If this option is not set the \fIzen container\fP will
 be created on a vacant workspace (the highest
 numbered workspace + 1).
 
 .SH USAGE
-.PP
 move current window to a "clean" workspace,
 put it in a centered, floating tabbed container.
 
@@ -50,19 +40,16 @@ triggering the command on a window that is already
 from.
 
 .SH CONTACT
-.PP
 Send bugs and feature requests to:
 .br
 https://github.com/budlabs/i3ass/issues
 
 .SH COPYRIGHT
-.PP
-Copyright (c) 2017-2023, budRich of budlabs
+Copyright (c) 2017-2025, budRich of budlabs
 .br
 SPDX-License-Identifier: MIT
 
 .SH SEE ALSO
-.PP
 https://www.reddit.com/r/i3wm/comments/6x8ajm/oc_i3zen/
 .br
 https://www.reddit.com/r/unixporn/comments/6xbdtk/oci3_i3zen/


### PR DESCRIPTION
##  i3fyra --mono 
Monocle mode toggle. If used on i3fyra workspace
will make currently focused fyra container the only visible.
If it already is the only visible, this command will show
the other containers. This includes some smart logic, so
it remembers which windows where hidden, so toggling back and forth
works smooth.

If window is not on i3fyra workspace, this command will toggle fullscreen.
(#225 @1ntronaut )

## i3fyra --rotate family|sibling
swaps place of families or siblings with one command.
To achieve this before you needed to first hide the target
then show it on the opposite direction (that still works btw)

## i3fyra --orientation
Now supports `toggle` argument  
(#218 @1ntronaut )


## i3king GLOBAL/DEFAULT rules without a criteria
was never parsed. big thanks to @TimRegeant && @1ntronaut
for reporting and helping out with this (#214)

## Don't trigger i3king rules on float toggle on non-i3fyra workspace

## i3ass command now includes i3run, i3term, i3menu and dmenu
(#218 @1ntronaut )
