### PR TITLE
[LIST][ADD] container ID for fyra parent containers

### DIFF
--- a/docs/releasenotes/0next.md
+++ b/docs/releasenotes/0next.md
@@ -6,3 +6,10 @@ Also added short option -S
 i3list has ACM and TCM (active/target container monocled)
 and i3get has `--print M` , both commands will say
 **1** if container is monocled, or **0** if it isn't
+
+## add parent container ID to i3list output
+
+desc["CAP"]="Container A Container ID"
+desc["CBP"]="Container B Container ID"
+desc["CCP"]="Container C Container ID"
+desc["CDP"]="Container D Container ID"

--- a/src/i3list/awklib/END.awk
+++ b/src/i3list/awklib/END.awk
@@ -118,7 +118,8 @@ END {
         key="C" container_name "L"; printf(strfrm,key, ac[container_id]["layout"], desc[key])
         key="C" container_name "W"; printf(strfrm,key, ac[workspace_id]["num"], desc[key])
         key="C" container_name "N"; printf(strfrm,key, ac[workspace_id]["name"], desc[key])
-
+        key="C" container_name "P"; printf(strfrm,key, container_id, desc[key])
+        
         focused=ac[container_id]["focused"]
         # make sure the focused container is a window
         # while (!("window" in ac[focused]))

--- a/src/i3list/awklib/descriptions.awk
+++ b/src/i3list/awklib/descriptions.awk
@@ -17,6 +17,11 @@ function descriptions() {
   desc["CDW"]="Container D Workspace number"
   desc["CDN"]="Container D Workspace name"
 
+  desc["CAP"]="Container A Container ID"
+  desc["CBP"]="Container B Container ID"
+  desc["CCP"]="Container C Container ID"
+  desc["CDP"]="Container D Container ID"
+
   desc["SAB"]="Current split: AB"
   desc["SAC"]="Current split: AC"
   desc["SBD"]="Current split: BD"
@@ -53,6 +58,7 @@ function descriptions() {
   desc["ATW"]="Active Window tab width"
   desc["ABW"]="Active Window border width"
   desc["APA"]="Active Window parent ID"
+  desc["ACM"]="Active Container is monocled"
 
   desc["TWF"]="Target Window Floating"
   desc["TWC"]="Target Window con_id"
@@ -72,6 +78,7 @@ function descriptions() {
   desc["TWB"]="Target Window titlebar height"
   desc["TBW"]="Target Window border width"
   desc["TPA"]="Target Window parent ID"
+  desc["TCM"]="Target Container is monocled"
   
   desc["WAW"]="Active Workspace width"
   desc["WAH"]="Active Workspace height"


### PR DESCRIPTION
When experimenting writing a script that achieved cycle focus|swap|move (#231) i realized it would be handy to know the container ID of the A,B,C,D containers and was surprised i never included that in i3list output. 